### PR TITLE
Add Python API examples to basic usage section

### DIFF
--- a/docs/get_started/basic_usage/01_Get-Storage-Access.md
+++ b/docs/get_started/basic_usage/01_Get-Storage-Access.md
@@ -6,7 +6,7 @@
 For the general access a registered account within the official NFDI/NFDI4Biodiversity/GFBio AAI is needed to obtain a valid OIDC token from one of those.
 
 After login, you can use your OIDC token to register yourself at an AOS instance. 
-To create/modify resources within the given scope/permissions you have to generate API token(s) after you have been activated by an administrator.
+To create/modify resources within the given scope/permissions you have to generate API token(s) after you have been activated by an AOS instance administrator.
 
 Please note that these following tutorials cover only the most basic operations. 
 For a complete list of the public API endpoints, their matching requests and responses, please refer to our [Aruna Object Storage REST API Swagger-UI](https://api.aruna.nfdi-dev.gi.denbi.de/swagger-ui/){:target="_blank"}.
@@ -20,7 +20,7 @@ The presence of a client connection to the specific resource service is required
 
 !!! Danger
 
-    This is a minimal reproducible example for demonstration which should not be used 'as-is' in a production environment!
+    These are minimal reproducible examples only for demonstration purposes which should not be used 'as-is' in a production environment!
 
 === "Rust"
 
@@ -49,7 +49,7 @@ The presence of a client connection to the specific resource service is required
             let mut mut_req: tonic::Request<()> = request;
             let metadata = mut_req.metadata_mut();
             metadata.append(
-                AsciiMetadataKey::from_bytes("Authorization".as_bytes()).unwrap(),
+                AsciiMetadataKey::from_bytes("authorization".as_bytes()).unwrap(),
                 AsciiMetadataValue::try_from(format!("Bearer {}", self.api_token.as_str())).unwrap(),
             );
     

--- a/docs/get_started/basic_usage/01_Get-Storage-Access.md
+++ b/docs/get_started/basic_usage/01_Get-Storage-Access.md
@@ -176,7 +176,45 @@ The presence of a client connection to the specific resource service is required
         **All Python examples in this documentation assume that the client services have been initialized with an interceptor.**
 
     ```python
-    Coming Soon ...
+    import grpc
+
+    from aruna.api.storage.services.v1.collection_service_pb2_grpc import CollectionServiceStub
+    from aruna.api.storage.services.v1.object_service_pb2_grpc import ObjectServiceStub
+    from aruna.api.storage.services.v1.objectgroup_service_pb2_grpc import ObjectGroupServiceStub
+    from aruna.api.storage.services.v1.project_service_pb2_grpc import ProjectServiceStub
+    from aruna.api.storage.services.v1.user_service_pb2_grpc import UserServiceStub
+    
+    # Valid Aruna API token
+    #   In a production environment this should be stored in a more secure location ...
+    API_TOKEN = 'MySecretArunaApiToken'
+    
+    # AOS instance gRPC gateway endpoint
+    AOS_HOST = '<URL-To-AOS-Instance-gRPC-Gateway>' # Protocol (e.g. https://) has to be omitted
+    AOS_PORT = '443'
+    
+
+    class AosClient(object):
+        """
+        Class to contain the AOS gRPC client service stubs for easier usage.
+        """
+        def __init__(self):
+            # Read TLS credentials from local trusted certificates and instantiate a channel
+            ssl_credentials = grpc.ssl_channel_credentials()
+            self.channel    = grpc.secure_channel("{}:{}".format(AOS_HOST, AOS_PORT), ssl_credentials)
+    
+            self.user_client = UserServiceStub(self.channel)
+            self.project_client = ProjectServiceStub(self.channel)
+            self.collection_client = CollectionServiceStub(self.channel)
+            self.object_client = ObjectServiceStub(self.channel)
+            self.object_group_client = ObjectGroupServiceStub(self.channel)
+    
+
+    # Entry point of the Python script
+    if __name__ == '__main__':
+        # Instantiate AosClient
+        client = AosClient()
+        
+        # Do something with the client services ...
     ```
 
 

--- a/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
+++ b/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
@@ -135,6 +135,44 @@ It also makes it easy to restrict or extend a user's permissions for a project w
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to add user with admin permissions to a project
+    request = AddUserToProjectRequest(
+        project_id="<project-id>",
+        user_permission=ProjectPermission(
+            user_id="<user-id>",
+            project_id="<project-id>",
+            permission=Permission.Value("PERMISSION_ADMIN")  # Needs int, therefore .Value()
+        )
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.AddUserToProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to add user with read only permissions to a project
+    request = AddUserToProjectRequest(
+        project_id="<project-id>",
+        user_permission=ProjectPermission(
+            user_id="<user-id>",
+            project_id="<project-id>",
+            permission=Permission.Value("PERMISSION_READ")   # Needs int, therefore .Value()
+        )
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.AddUserToProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Edit Project user permission
 
@@ -185,6 +223,26 @@ The assigned permissions to the users can be changed by project administrators a
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to set a users permission to read only for the specific project
+    request = EditUserPermissionsForProjectRequest(
+        project_id="<project-id>",
+        user_permission=ProjectPermission(
+            user_id="<user-id>",
+            project_id="<project-id>",
+            permission=Permission.Value("PERMISSION_READ")  # Needs int, therefore .Value()
+        )
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.EditUserPermissionsForProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Remove Project user
 
@@ -221,6 +279,22 @@ However, access with project/collection scoped tokens is not restricted with the
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to remove a user from a specific project
+    request = RemoveUserFromProjectRequest(
+        project_id="<project-id>",
+        user_id="<user-id>"
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.RemoveUserFromProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -326,6 +400,61 @@ Here are some API examples on generating API tokens with individual scopes and p
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to create a global/personal API token with expiration date
+    request = CreateAPITokenRequest(
+        project_id="",  # Paramater can also be omitted if empty
+        collection_id="",  # Paramater can also be omitted if empty
+        name="MyPersonalToken",
+        expires_at=ExpiresAt(
+            timestamp=Timestamp(seconds=int(datetime.datetime(2023, 1, 1).timestamp()))
+        ),
+        permission=Permission.Value("PERMISSION_NONE")  # Paramater can also be omitted for personal tokens
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.CreateAPIToken(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to create a project scoped API token with MODIFY permission
+    request = CreateAPITokenRequest(
+        project_id="<project-id>",
+        collection_id="",  # Paramater can also be omitted if empty
+        name="ProjectReadOnly",
+        expires_at=None,  # Paramater can also be omitted if None
+        permission=Permission.Value("PERMISSION_MODIFY")
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.CreateAPIToken(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to create a collection scoped API token with APPEND permission
+    request = CreateAPITokenRequest(
+        project_id="",  # Paramater can also be omitted if empty
+        collection_id="<collection-id>",  
+        name="ProjectReadOnly",
+        expires_at=None,  # Paramater can also be omitted if None
+        permission=Permission.Value("PERMISSION_APPEND")
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.CreateAPIToken(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Get API token(s)
 
@@ -381,6 +510,32 @@ API examples to fetch info of a specific token or all tokens of the current user
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to get info on a specific API token by its id
+    request = GetAPITokenRequest(
+        token_id="<token-id>"
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.GetAPIToken(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to get info on all tokens associated with the current user
+    request = GetAPITokensRequest()
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.GetAPITokens(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -440,4 +595,30 @@ API examples to revoke/delete a specific API token or all tokens of the current 
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to revoke the specific API token
+    request = DeleteAPITokenRequest(
+        token_id="<token-id>"
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.DeleteAPIToken(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to to revoke all tokens of the current user
+    request = DeleteAPITokensRequest()
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.DeleteAPITokens(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
     ```

--- a/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
+++ b/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
@@ -185,7 +185,7 @@ The assigned permissions to the users can be changed by project administrators a
 === "Bash"
 
     ```bash
-    # Native JSON request to add user with admin permissions to a project
+    # Native JSON request to set a users permission to read only for the specific project
     curl -d '
       {
         "userPermission": {
@@ -202,7 +202,7 @@ The assigned permissions to the users can be changed by project administrators a
 === "Rust"
 
     ```rust
-    // Create tonic/ArunaAPI request to set a users permission to read-only for the specific project
+    // Create tonic/ArunaAPI request to set a users permission to read only for the specific project
     let edit_request = EditUserPermissionsForProjectRequest {
         project_id: "<project-id>".to_string(),
         user_permission: Some(ProjectPermission {
@@ -247,6 +247,7 @@ The assigned permissions to the users can be changed by project administrators a
 ## Remove Project user
 
 Users can, of course, also be completely removed from projects again, depriving them of any access with personalized tokens. 
+
 However, access with project/collection scoped tokens is not restricted with the removal of the user.
 
 !!! Info
@@ -369,7 +370,7 @@ Here are some API examples on generating API tokens with individual scopes and p
     In any case it is recommended to implement the `From<NativeDateTime>` or `TryFrom<NativeDateTime>` trait for the Timestamp Struct.
 
     ```rust
-    // Create tonic/ArunaAPI request to create a global/personal API token with expiration
+    // Create tonic/ArunaAPI request to create a global/personal API token with expiration date
     let expires_at = NaiveDate::from_ymd(2023, 01, 01).and_hms(0, 0, 0);
     let create_request = CreateApiTokenRequest {
         project_id: "".to_string(), 
@@ -405,13 +406,13 @@ Here are some API examples on generating API tokens with individual scopes and p
     ```python
     # Create tonic/ArunaAPI request to create a global/personal API token with expiration date
     request = CreateAPITokenRequest(
-        project_id="",  # Paramater can also be omitted if empty
-        collection_id="",  # Paramater can also be omitted if empty
+        project_id="",  # Parameter can also be omitted if empty
+        collection_id="",  # Parameter can also be omitted if empty
         name="MyPersonalToken",
         expires_at=ExpiresAt(
             timestamp=Timestamp(seconds=int(datetime.datetime(2023, 1, 1).timestamp()))
         ),
-        permission=Permission.Value("PERMISSION_NONE")  # Paramater can also be omitted for personal tokens
+        permission=Permission.Value("PERMISSION_NONE")  # Parameter can also be omitted for personal tokens
     )
     
     # Send the request to the AOS instance gRPC gateway
@@ -425,9 +426,9 @@ Here are some API examples on generating API tokens with individual scopes and p
     # Create tonic/ArunaAPI request to create a project scoped API token with MODIFY permission
     request = CreateAPITokenRequest(
         project_id="<project-id>",
-        collection_id="",  # Paramater can also be omitted if empty
+        collection_id="",  # Parameter can also be omitted if empty
         name="ProjectReadOnly",
-        expires_at=None,  # Paramater can also be omitted if None
+        expires_at=None,  # Parameter can also be omitted if None
         permission=Permission.Value("PERMISSION_MODIFY")
     )
     
@@ -441,10 +442,10 @@ Here are some API examples on generating API tokens with individual scopes and p
     ```python
     # Create tonic/ArunaAPI request to create a collection scoped API token with APPEND permission
     request = CreateAPITokenRequest(
-        project_id="",  # Paramater can also be omitted if empty
+        project_id="",  # Parameter can also be omitted if empty
         collection_id="<collection-id>",  
         name="ProjectReadOnly",
-        expires_at=None,  # Paramater can also be omitted if None
+        expires_at=None,  # Parameter can also be omitted if None
         permission=Permission.Value("PERMISSION_APPEND")
     )
     

--- a/docs/get_started/basic_usage/03_How-To-Project.md
+++ b/docs/get_started/basic_usage/03_How-To-Project.md
@@ -49,6 +49,22 @@ API example for creating a new Project.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to create a project
+    request = CreateProjectRequest(
+        name="Python-API-Test-Project",
+        description="This project was created with the gRPC Python API client."
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.CreateProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Get Project
 
@@ -85,6 +101,21 @@ API example for fetching info of an existing Project.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of a project
+    request = GetProjectRequest(
+        project_id="<project-id>"
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.GetProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Get all Projects of User
 
@@ -119,6 +150,21 @@ API example for fetching all registered Projects a specific user is associated w
     
     // Do something with the response
     println!("{:#?}\n", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of all projects a specific user is member of
+    request = GetUserProjectsRequest(
+        user_id=""  # Parameter can be omitted if empty
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.user_client.GetUserProjects(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -169,6 +215,23 @@ API example for updating an existing Project.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to update the metadata of a project
+    request = UpdateProjectRequest(
+        project_id="<project-id>",
+        name="Python-API-Test-Project",
+        description="This project was updated with the gRPC Python API client."
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.UpdateProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Delete Project
 
@@ -208,4 +271,19 @@ API examples for deleting a Project.
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to delete a project
+    request = UDestroyProjectRequest(
+        project_id="<project-id>"
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.project_client.DestroyProject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')
     ```

--- a/docs/get_started/basic_usage/03_How-To-Project.md
+++ b/docs/get_started/basic_usage/03_How-To-Project.md
@@ -22,8 +22,8 @@ API example for creating a new Project.
     # Native JSON request to create a project
     curl -d '
       {
-        "name": "DummyProject", 
-        "description": "This is a new dummy project."
+        "name": "cURL-API-Test-Project", 
+        "description": "This project was created with a cURL request."
       }' \
          -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -36,7 +36,7 @@ API example for creating a new Project.
     // Create tonic/ArunaAPI request to create a project
     let create_request = CreateProjectRequest {
         name: "Rust-API-Test-Project".to_string(),
-        description: "This project was created through the Rust API.".to_string(),
+        description: "This project was created with the gRPC Rust API client.".to_string(),
     };
     
     // Send the request to the AOS instance gRPC gateway
@@ -187,8 +187,8 @@ API example for updating an existing Project.
     # Native JSON request to update the metadata of a project
     curl -d '
       {
-        "name": "Updated Dummy Project", 
-        "description": "This is an updated dummy project."
+        "name": "cURL-API-Test-Project", 
+        "description": "This project was updated with a cURL request."
       }' \
          -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -202,7 +202,7 @@ API example for updating an existing Project.
     let update_request = UpdateProjectRequest {
         project_id: "<project-id>".to_string(),
         name: "Rust-API-Test-Project".to_string(),
-        description: "This project was updated through the Rust API.".to_string(),
+        description: "This project was updated with the gRPC Rust API client.".to_string(),
     };
     
     // Send the request to the AOS instance gRPC gateway
@@ -277,7 +277,7 @@ API examples for deleting a Project.
 
     ```python
     # Create tonic/ArunaAPI request to delete a project
-    request = UDestroyProjectRequest(
+    request = DestroyProjectRequest(
         project_id="<project-id>"
     )
     

--- a/docs/get_started/basic_usage/04_How-To-Collections.md
+++ b/docs/get_started/basic_usage/04_How-To-Collections.md
@@ -82,6 +82,33 @@ API example for creating a new Collection.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to create a new collection
+    request = CreateNewCollectionRequest(
+        name="Python-API-Test-Collection",
+        description="This collection was created with the gRPC Python API client.",
+        project_id="<project-id>",
+        labels=[KeyValue(
+            key="LabelKey",
+            value="LabelValue"
+        )],
+        hooks=[KeyValue(
+            key="HookKey",
+            value="HookValue"
+        )],
+        label_ontology=LabelOntology(["LabelKey"]),
+        dataclass=DataClass.Value("DATACLASS_PRIVATE")
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.CreateNewCollection(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Get Collection(s)
 
@@ -195,6 +222,77 @@ API examples for fetching one or multiple existing Collection/s.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of a collection
+    request = GetCollectionByIDRequest(
+        collection_id="<collection-id>"
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.GetCollectionByID(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request fetch first 20 collections of a project
+    request = GetCollectionsRequest(
+        project_id="<project-id>",
+        label_or_id_filter=None,  # Parameter can also be omitted if None
+        page_request=None  # Parameter can also be omitted if None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.GetCollections(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by their ids
+    GetCollectionsRequest(
+        project_id="<project-id>",
+        label_or_id_filter=LabelOrIDQuery(
+            labels=None,  # Parameter can also be omitted if None
+            ids=["<collection-id-001",
+                 "<collection-id-002"]
+        ),
+        page_request=None  # Parameter can also be omitted if None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.GetCollections(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by label keys
+    request = GetCollectionsRequest(
+        project_id="<project-id>",
+        label_or_id_filter=LabelOrIDQuery(
+            labels=LabelFilter(
+                labels=[KeyValue(key="LabelKey")],
+                and_or_or=False,
+                keys_only=True
+            ),
+            ids=None  # Parameter can also be omitted if None
+        ),
+        page_request=None  # Parameter can also be omitted if None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.GetCollections(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Update Collection
 
@@ -282,6 +380,35 @@ API example for updating a Collection.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to update a collections name and description
+    request = UpdateCollectionRequest(
+        project_id="<project-id>",
+        collection_id="<collection-id>",
+        name="Python-API-Updated-Collection",
+        description="This collection was updated with the gRPC Python API client.",
+        labels=[KeyValue(
+            key="LabelKey",
+            value="LabelValue"
+        )],
+        hooks=[KeyValue(
+            key="HookKey",
+            value="HookValue"
+        )],
+        label_ontology=LabelOntology(["LabelKey"]),
+        dataclass=DataClass.Value("DATACLASS_PRIVATE"),
+        version=None  # Parameter can also be omitted if None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.UpdateCollection(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Pin Collection
 
@@ -332,6 +459,26 @@ Pinned collections can not be updated in place anymore.
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to pin a collection to a specific version
+    request = PinCollectionVersionRequest(
+        collection_id="<collection-id>",
+        version=Version(
+            major=1,
+            minor=2,
+            patch=3
+        )
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.PinCollectionVersion(request=request)
+
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -410,4 +557,36 @@ API examples for deleting a Collection.
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to delete a collection
+    request = DeleteCollectionRequest(
+        collection_id="<collection-id>",
+        project_id="<project-id>",
+        force=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.DeleteCollection(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to delete a collection with force
+    request = DeleteCollectionRequest(
+        collection_id="<collection-id>",
+        project_id="<project-id>",
+        force=True
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.collection_client.DeleteCollection(request=request)
+
+    # Do something with the response
+    print(f'{response}')
     ```

--- a/docs/get_started/basic_usage/04_How-To-Collections.md
+++ b/docs/get_started/basic_usage/04_How-To-Collections.md
@@ -23,8 +23,8 @@ API example for creating a new Collection.
     # Native JSON request to create a new collection
     curl -d '
       {
-        "name": "DummyCollection",
-        "description": "Description of a dummy collection.",
+        "name": "cURL-API-Test-Collection",
+        "description": "This collection was created with a cURL request.",
         "projectId": "<project-id>",
         "labels": [
           {
@@ -56,7 +56,7 @@ API example for creating a new Collection.
     // Create tonic/ArunaAPI request to create a new collection
     let create_request = CreateNewCollectionRequest {
         name: "Rust-API-Test-Collection".to_string(),
-        description: "This collection was created through the Rust API.".to_string(),
+        description: "This collection was created with the gRPC Rust API client.".to_string(),
         project_id: "<project-id>".to_string(),
         labels: vec![KeyValue {
             key: "LabelKey".to_string(),
@@ -99,7 +99,7 @@ API example for creating a new Collection.
             value="HookValue"
         )],
         label_ontology=LabelOntology(["LabelKey"]),
-        dataclass=DataClass.Value("DATACLASS_PRIVATE")
+        dataclass=DataClass.Value("DATA_CLASS_PRIVATE")
     )
 
     # Send the request to the AOS instance gRPC gateway
@@ -137,7 +137,7 @@ API examples for fetching one or multiple existing Collection/s.
 === "Rust"
 
     ```rust
-    // Create tonic/ArunaAPI request fetch information of a collection
+    // Create tonic/ArunaAPI request to fetch information of a collection
     let get_request = GetCollectionByIdRequest {
         collection_id: "<collection-id>".to_string(),
     };
@@ -153,7 +153,7 @@ API examples for fetching one or multiple existing Collection/s.
     ```
     
     ```rust
-    // Create tonic/ArunaAPI request fetch all collections of a project
+    // Create tonic/ArunaAPI request to fetch all collections of a project
     let get_request = GetCollectionsRequest {
         project_id: "<project-id>".to_string(),
         label_or_id_filter: None,
@@ -171,7 +171,7 @@ API examples for fetching one or multiple existing Collection/s.
     ```
     
     ```rust
-    // Create tonic/ArunaAPI request fetch multiple collections of a project filtered by their ids
+    // Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by their ids
     let get_request = GetCollectionsRequest {
         project_id: "<project-id>".to_string(),
         label_or_id_filter: Some(LabelOrIdQuery {
@@ -195,7 +195,7 @@ API examples for fetching one or multiple existing Collection/s.
     ```
     
     ```rust
-    // Create tonic/ArunaAPI request fetch multiple collections of a project filtered by label keys
+    // Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by label keys
     let get_request = GetCollectionsRequest {
         project_id: "<project-id>".to_string(),
         label_or_id_filter: Some(LabelOrIdQuery {
@@ -398,7 +398,7 @@ API example for updating a Collection.
             value="HookValue"
         )],
         label_ontology=LabelOntology(["LabelKey"]),
-        dataclass=DataClass.Value("DATACLASS_PRIVATE"),
+        dataclass=DataClass.Value("DATA_CLASS_PRIVATE"),
         version=None  # Parameter can also be omitted if None
     )
 

--- a/docs/get_started/basic_usage/05_How-To-Objects.md
+++ b/docs/get_started/basic_usage/05_How-To-Objects.md
@@ -146,7 +146,7 @@ You also have to request an upload url for each part individually.
     curl -X PUT -T <path-to-local-file> <upload-url>
     ```
 
-=== "Bash"
+=== "Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to request an upload url for single part upload
@@ -612,6 +612,8 @@ On success the response will contain all the information on the finished Object.
 
 Information on finished or staging Objects can be fetched with their id and the id of their collection.
 
+The `with_url` (or `withUrl`) parameter controls if the response includes a download URL for the specific object.
+
 !!! Info
 
     This request needs at least READ permissions on the Object's Collection or the Project under which the Collection is registered.
@@ -625,7 +627,15 @@ Information on finished or staging Objects can be fetched with their id and the 
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}
     ```
 
+    ```bash
+    # Native JSON request to fetch information of an object by its unique id including a download url
+    curl -H 'Authorization: Bearer <API_TOKEN>' \
+         -H 'Content-Type: application/json' \
+         -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}?withUrl=true
+    ```
+
 === "Rust"
+
     ```rust
     // Create tonic/ArunaAPI request to fetch information of an object
     let get_request = GetObjectByIdRequest {
@@ -1673,7 +1683,7 @@ This process consists of two steps:
       }' \
          -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
-         -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<source-collection-id>/object/<object-id>
+         -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<source-collection-id>/object/<source-object-id>
     ```
 
 === "Rust"
@@ -1699,7 +1709,7 @@ This process consists of two steps:
     
     // Create tonic/ArunaAPI request to delete the object in the source collection
     let delete_request = DeleteObjectRequest {
-        object_id: "<object-id>".to_string(),
+        object_id: "<source-object-id>".to_string(),
         collection_id: "<source-collection-id>".to_string(),
         with_revisions: true,
         force: false,

--- a/docs/get_started/basic_usage/05_How-To-Objects.md
+++ b/docs/get_started/basic_usage/05_How-To-Objects.md
@@ -85,6 +85,40 @@ As long as an Object is in the staging area data can be uploaded to it.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to initialize an staging object
+    request = InitializeNewObjectRequest(
+        object=StageObject(
+            filename="aruna.png",
+            description="Aruna Object Storage logo",
+            collection_id="<collection-id>",
+            content_len=123456,
+            source=None,  # Parameter can also be omitted if None
+            dataclass=DataClass.Value("DATACLASS_PRIVATE"),
+            labels=[KeyValue(
+                key="LabelKey",
+                value="LabelValue"
+            )],
+            hooks=[KeyValue(
+                key="HookKey",
+                value="HookValue"
+            )]
+        ),
+        collection_id="<collection-id>",
+        preferred_endpoint_id="",  # Parameter can also be omitted if empty
+        multipart=False,
+        is_specification=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.InitializeNewObject(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Upload data to an Staging Object
 
@@ -153,6 +187,35 @@ You also have to request an upload url for each part individually.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to request an upload url for single part upload
+    request = GetUploadURLRequest(
+        object_id="<object-id>",
+        upload_id="<upload-id>",
+        collection_id="<collection-id>",
+        multipart=False,
+        part_number=1
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetUploadURL(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    upload_url = response.url.url
+
+    # Upload local file to the generated upload URL
+    file_path = "/tmp/aruna.png"
+    headers = {'Content-type': 'application/octet-stream'}
+    upload_response = requests.put(upload_url, data=open(file_path, 'rb'), headers=headers)
+
+    # Do something with the response
+    print(f'{upload_response}')
+    ```
+
+
 ### Multipart upload
 
 !!! Note
@@ -202,6 +265,26 @@ You also have to request an upload url for each part individually.
     // Do something with the response
     println!("{:#?}", response);
     ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to request an upload url for specific part of multipart upload
+    request = GetUploadURLRequest(
+        object_id="<object-id>",
+        upload_id="<upload-id>",
+        collection_id="<collection-id>",
+        multipart=True,
+        part_number=<part-number>
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetUploadURL(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ##### Multipart upload example
 
@@ -287,6 +370,69 @@ You also have to request an upload url for each part individually.
     
     // Retain the completed parts for usage in the FinishObjectRequest
     println!("{:#?}", completed_parts);
+    ```
+
+=== "Python"
+
+    ```python
+    CHUNK_SIZE = 1024 * 1024 * 50;  # 50MiB chunks
+    
+    file_path = "/path/to/local/file"
+    headers = {'Content-type': 'application/octet-stream'}  # Arbitrary binary data upload
+    completed_parts = []
+    
+    # Open file and return a stream
+    with open(file_path, 'rb') as file_in:
+        for i, data_chunk in enumerate(read_file_chunks(file_in, CHUNK_SIZE)):  # (1)
+            # Create tonic/ArunaAPI request to request an upload url for multipart upload part
+            get_request = GetUploadURLRequest(
+                object_id="<object-id>",
+                upload_id="<upload-id>",
+                collection_id="<collection-id>",
+                multipart=True,
+                part_number=i+1
+            )
+
+            # Send the request to the AOS instance gRPC gateway
+            get_response = client.object_client.GetUploadURL(request=get_request)
+
+            # Extraxt download url from response
+            upload_url = get_response.url.url
+
+            # Upload file content chunk to upload url
+            upload_response = requests.put(upload_url, data=data_chunk, headers=headers)
+
+            # Parse ETag from response header
+            etag = str(upload_response.headers["etag"].replace("\"", ""))
+
+            # Collect ETag with corresponding part number
+            completed_parts.append(
+                CompletedParts(
+                    etag=etag,
+                    part=i+1
+                )
+            )
+
+    # Retain the completed parts for usage in the FinishObjectRequest
+    print(f'{completed_parts}')
+    ```
+
+    1. **This function returns a generator with byte chunks of the specified file:**
+    ```python
+        def read_file_chunks(file_object, chunk_size=5242880):
+        """
+        Generator to read set chunk sizes of a file object.
+        Args:
+            file_object: Open file handle
+            chunk_size: Size of chunk to read (Default: 5MiB)
+        
+        Returns: Generator with file content bytes in chunk size
+        """
+        while True:
+            data = file_object.read(chunk_size)
+            if not data:
+                break
+            yield data
     ```
 
 
@@ -406,6 +552,61 @@ On success the response will contain all the information on the finished Object.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to finish a single part upload staging object
+    request = FinishObjectStagingRequest(
+        object_id="<object-id>",
+        upload_id="<upload-id>",
+        collection_id="<collection-id>",
+        hash=Hash(
+            alg=Hashalgorithm.Value("HASHALGORITHM_SHA256"),
+            hash="<sha256-file-hashsum>"  # E.g. 8e83e391f7d4bd995e772029a097d42f9fa4f433a8e99585d4a902f599dc7b9c
+        ),
+        no_upload=False,
+        completed_parts=[],
+        auto_update=True
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.FinishObjectStaging(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to finish a multipart upload staging object
+    finish_request = FinishObjectStagingRequest(
+        object_id="<object-id>",
+        upload_id="<upload-id>",
+        collection_id="<collection-id>",
+        hash=Hash(
+            alg=Hashalgorithm.Value("HASHALGORITHM_SHA256"),
+            hash="<sha256-file-hashsum>"  # E.g. 8e83e391f7d4bd995e772029a097d42f9fa4f433a8e99585d4a902f599dc7b9c
+        ),
+        no_upload=False,
+        completed_parts=[
+            CompletedParts(
+                etag="<upload-etag>",  # E.g. bfa7d257edcc9b962b7ab1a0a75b9808
+                part=1
+             ),
+            CompletedParts(
+                etag="<upload-etag>",  # E.g. af62c64eb6bcc9890d0aadf5720bf1ff
+                part=2
+            )
+        ],
+        auto_update=True
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.FinishObjectStaging(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Get Object
 
@@ -441,6 +642,23 @@ Information on finished or staging Objects can be fetched with their id and the 
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to to fetch information of an object
+    request = GetObjectByIDRequest(
+        object_id="<object-id>",
+        collection_id="<collection-id>",
+        with_url=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetObjectByID(request=request)
+
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -608,6 +826,106 @@ Additionally, you can include id or label filters to narrow the returned Objects
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of the first 20 unfiltered objects in a collection
+    request = GetObjectsRequest(
+        collection_id="<collection-id>",
+        page_request=None,
+        label_id_filter=None,
+        with_url=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of the first 250 unfiltered objects in a collection
+    request = GetObjectsRequest(
+        collection_id="<collection-id>",
+        page_request=PageRequest(
+            last_uuid="",  # Parameter can also be omitted if empty
+            page_size=250
+        ),
+        label_id_filter=None,
+        with_url=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of the objects 21-40 (i.e. the next page) in a collection
+    request = GetObjectsRequest(
+        collection_id="<collection-id>",
+        page_request=PageRequest(
+            last_uuid="<last-received-object-id>",
+            page_size=0  # Parameter can also be omitted if <= 0
+        ),
+        label_id_filter=None,  # Parameter can also be omitted if None
+        with_url=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of all objects in a collection matching one of the provided ids
+    request = GetObjectsRequest(
+        collection_id="<collection-id>",
+        page_request=None,  # Parameter can also be omitted if None
+        label_id_filter=LabelOrIDQuery(
+            labels=None,  # Parameter can also be omitted if None
+            ids=["<object-id-001>", "<object-id-001>"]
+        ),
+        with_url=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch multiple objects of a collection filtered by label key(s)
+    request = GetObjectsRequest(
+        collection_id="<collection-id>",
+        page_request=None,  # Parameter can also be omitted if None
+        label_id_filter=LabelOrIDQuery(
+            labels=LabelFilter(
+                labels=[KeyValue(
+                    key="isDummyObject",
+                    value=""  # Parameter can also be omitted if empty or keys_only=True
+                )],
+                and_or_or=False,
+                keys_only=True
+            )
+        ),
+        with_url=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Download Object data
 
@@ -673,6 +991,40 @@ This can be done with an individual request or directly while getting informatio
     copy(&mut content, &mut target_file).unwrap();
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch an Objects download url
+    download_url_request = GetDownloadURLRequest(
+        collection_id="<collection-id>",
+        object_id="<object-id>"
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    download_url_response = client.object_client.GetDownloadURL(request=download_url_request)
+
+    # Extract download url from response
+    download_url = download_url_response.url.url
+
+    # Try to extract filename from download url query parameter
+    parsed_url = urlparse(download_url)
+    local_filename = parse_qs(parsed_url.query)['filename'][0]
+    
+    if local_filename is None:
+        local_filepath = os.path.join("/tmp", f'object.{object_id}')
+    else:
+        local_filepath = os.path.join("/tmp", local_filename)
+
+    # Send GET request to download url
+    with requests.get(download_url, stream=True) as r:
+        r.raise_for_status()
+
+        // Write response content in chunks to local file
+        with open(local_filepath, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=8192):  # Chunk size can be adapted
+                f.write(chunk)
+    ```
+
 
 ## Update Object
 
@@ -725,6 +1077,26 @@ Just adding one or multiple labels to an Object does not create a new revision.
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to add a label to an object
+    request = AddLabelToObjectRequest(
+        object_id="<object-id>",
+        collection_id="<collection-id>",
+        labels_to_add=[KeyValue(
+            key="AnotherKey",
+            value="AnotherValue"
+        )]
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.AddLabelToObject(request=request)
+
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -848,6 +1220,63 @@ Comparable to the Object initialization process, the updated Object must be fini
     // Do something with the response
     println!("{:#?}", response);
     ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to update an objects description
+    update_request = UpdateObjectRequest(
+        object_id="<object-id>",
+        collection_id="<collection-id>",
+        object=StageObject(
+            filename="aruna.png",
+            description="An updated description of the AOS logo.",
+            collection_id="<collection-id>",
+            content_len=123456,
+            source=None,  # Parameter can also be omitted if None
+            dataclass=DataClass.Value("DATACLASS_PRIVATE"),
+            labels=[KeyValue(
+                key="LabelKey",
+                value="LabelValue"
+            )],
+            hooks=[KeyValue(
+                key="HookKey",
+                value="HookValue"
+            )]
+        ),
+        reupload=False,
+        preferred_endpoint_id="",  # Parameter can also be omitted if empty
+        multi_part=False,  # Parameter can also be omitted if `reupload=False`
+        is_specification=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    update_response = client.object_client.UpdateObject(request=update_request)
+
+    # Do something with the response
+    print(f'{update_response}')
+
+    # Create tonic/ArunaAPI request to finish a single part upload staging object
+    finish_request = FinishObjectStagingRequest(
+        object_id=update_response.object_id,
+        upload_id=update_response.upload_id,
+        collection_id=update_response.collection_id,
+        hash=Hash(
+            alg=Hashalgorithm.Value("HASHALGORITHM_SHA256"),
+            hash="<sha256-file-hashsum>"  # E.g. 8e83e391f7d4bd995e772029a097d42f9fa4f433a8e99585d4a902f599dc7b9c
+        ),
+        no_upload=True,
+        completed_parts=[],
+        auto_update=True
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    finish_response = client.object_client.FinishObjectStaging(request=finish_request)
+
+    # Do something with the response
+    print(f'{finish_response}')
+    ```
+
 
 #### Update with data re-upload
 
@@ -1008,6 +1437,86 @@ Comparable to the Object initialization process, the updated Object must be fini
     println!("{:#?}", finish_response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to update an objects description as well as re-upload the data
+    update_request = UpdateObjectRequest(
+        object_id="<object-id>",
+        collection_id="<collection-id>",
+        object=StageObject(
+            filename="aruna.png",
+            description="An updated description of the AOS logo.",
+            collection_id="<collection-id>",
+            content_len=1234567,
+            source=None,  # Parameter can also be omitted if None
+            dataclass=DataClass.Value("DATACLASS_PRIVATE"),
+            labels=[KeyValue(
+                key="LabelKey",
+                value="LabelValue"
+            )],
+            hooks=[KeyValue(
+                key="HookKey",
+                value="HookValue"
+            )]
+        ),
+        reupload=True,
+        preferred_endpoint_id="",  # Parameter can also be omitted if empty
+        multi_part=False,  # Parameter can also be omitted if `reupload=False`
+        is_specification=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    update_response = client.object_client.UpdateObject(request=update_request)
+
+    # Do something with the response
+    print(f'{update_response}')
+
+    # Create tonic/ArunaAPI request to request an upload url for single part upload
+    get_request = GetUploadURLRequest(
+        object_id=update_response.object_id,
+        upload_id=update_response.upload_id,
+        collection_id=update_response.collection_id,
+        multipart=False,
+        part_number=1
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    get_response = client.object_client.GetUploadURL(request=get_request)
+
+    # Do something with the response
+    print(f'{get_response}')
+    upload_url = get_response.url.url
+
+    # Upload updated local file to the generated upload URL
+    file_path = "/path/to/updated/local/file"
+    headers = {'Content-type': 'application/octet-stream'}
+    upload_response = requests.put(upload_url, data=open(file_path, 'rb'), headers=headers)
+
+    # Do something with the response (e.g. check status if was successful)
+    print(f'{upload_response}')
+
+    # Create tonic/ArunaAPI request to finish a single part upload staging object
+    finish_request = FinishObjectStagingRequest(
+        object_id=update_response.object_id,
+        upload_id=update_response.upload_id,
+        collection_id=update_response.collection_id,
+        hash=Hash(
+            alg=Hashalgorithm.Value("HASHALGORITHM_SHA256"),
+            hash="<updated-file-sha256-hashsum>"  # E.g. b53d51ea15b07422bb19d5f8671174e7d45b04f21cfed652127f845f5945bf38
+        ),
+        no_upload=False,
+        completed_parts=[],
+        auto_update=True
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    finish_response = client.object_client.FinishObjectStaging(request=finish_request)
+
+    # Do something with the response
+    print(f'{finish_response}')
+    ```
+
 
 ## Create Object reference
 
@@ -1096,6 +1605,42 @@ A reference can be either _"read only"_, which means that the Object can not be 
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to create an auto-updated read-only reference to keep track of an object
+    request = CreateObjectReferenceRequest(
+        object_id="<object-id>",
+        collection_id="<source-collection-id>",
+        target_collection_id="<target-collection-id>",
+        writeable=False,
+        auto_update=True
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.CreateObjectReference(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to create a writeable reference in another collection for collaborative work
+    request = CreateObjectReferenceRequest(
+        object_id="<object-id>",
+        collection_id="<source-collection-id>",
+        target_collection_id="<target-collection-id>",
+        writeable=True,
+        auto_update=True
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.CreateObjectReference(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Move Object to other Collection
 
@@ -1170,6 +1715,39 @@ This process consists of two steps:
     println!("{:#?}", delete_response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to create a writeable reference in another collection
+    create_request = CreateObjectReferenceRequest(
+        object_id="<object-id>",
+        collection_id="<source-collection-id>",
+        target_collection_id="<target-collection-id>",
+        writeable=True,
+        auto_update=True
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    create_response = client.object_client.CreateObjectReference(request=create_request)
+
+    # Do something with the response
+    print(f'{create_response}')
+    
+    # Create tonic/ArunaAPI request to delete the object in the source collection
+    delete_request = DeleteObjectRequest(
+        object_id="<source-object-id>",
+        collection_id="<source-collection-id>",
+        with_revisions=True,
+        force=False
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    delete_response = client.object_client.DeleteObject(request=delete_request)
+    
+    # Do something with the response
+    print(f'Deleted: {delete_response}')
+    ```
+
 
 ## Get all Object references
 
@@ -1206,6 +1784,23 @@ You can fetch information of all references an Object has in different Collectio
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to
+    request = GetReferencesRequest(
+        object_id="<object-id>",
+        collection_id="<collection-id>",
+        with_revisions=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.GetReferences(request=request)
+
+    # Do something with the response
+    print(f'Deleted: {response}')
     ```
 
 
@@ -1269,3 +1864,19 @@ Permanent deletion conditions:
     // Do something with the response
     println!("{:#?}", response);
     ```
+
+=== "Python"
+
+    # Create tonic/ArunaAPI request to delete an object with all its revisions
+    request = DeleteObjectRequest(
+        object_id="<source-object-id>",
+        collection_id="<source-collection-id>",
+        with_revisions=True,
+        force=True
+    )
+    
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_client.DeleteObject(request=request)
+    
+    # Do something with the response
+    print(f'{response}')

--- a/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
+++ b/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
@@ -22,8 +22,8 @@ API example for creating an ObjectGroup.
     # Native JSON request to create a new object group
     curl -d '
       {
-        "name": "DummyGroup",
-        "description": "This is a dummy object group for testing purposes.",
+        "name": "cURL-API-Test-ObjectGroup",
+        "description": "This object group was created with a cURL request.",
         "objectIds": [
           "<object-id-001>",
           "<object-id-002>",
@@ -51,7 +51,7 @@ API example for creating an ObjectGroup.
     // Create tonic/ArunaAPI request to create a new object group
     let create_request = CreateObjectGroupRequest {
         name: "Rust-API-Test-ObjectGroup".to_string(),
-        description: "This object group was created through the Rust API.".to_string(),
+        description: "This object group was created with the gRPC Rust API client.".to_string(),
         collection_id: "<collection-id>".to_string(),
         object_ids: vec![
             "<object-id-001>".to_string(),
@@ -62,8 +62,8 @@ API example for creating an ObjectGroup.
             "<object-id-004>".to_string(),
         ],
         labels: vec![KeyValue {
-            key: "LabelKey".to_string(),
-            value: "LabelValue".to_string(),
+            key: "isDummyGroup".to_string(),
+            value: "true".to_string(),
         }],
         hooks: vec![],
     };
@@ -104,7 +104,8 @@ API example for creating an ObjectGroup.
     print(f'{response}')
     ```
 
-## Get ObjectGroup
+
+## Get ObjectGroup(s)
 
 Fetching information of an ObjectGroup only returns information of the ObjectGroup itself, not the containing Objects.
 
@@ -574,7 +575,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
         group_id: "<object-group-id>".to_string(),
         collection_id: "<collection-id>".to_string(),
         name: "Rust-API-Test-ObjectGroup".to_string(),
-        description: "This object group was updated through the Rust API.".to_string(),
+        description: "This object group was updated with the gRPC Rust API client.".to_string(),
         object_ids: vec![
             "<object-id-001>".to_string(),
             "<object-id-002>".to_string(),
@@ -582,8 +583,8 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
         ],
         meta_object_ids: vec!["<object-id-004>".to_string()],
         labels: vec![KeyValue {
-            key: "LabelKey".to_string(),
-            value: "LabelValue".to_string(),
+            key: "isDummyGroup".to_string(),
+            value: "true".to_string(),
         }],
         hooks: vec![],
     };
@@ -604,7 +605,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
         group_id: "<object-group-id>".to_string(),
         collection_id: "<collection-id>".to_string(),
         name: "Rust-API-Test-ObjectGroup".to_string(),
-        description: "This object group was updated through the Rust API.".to_string(),
+        description: "This object group was updated with the gRPC Rust API client.".to_string(),
         object_ids: vec![
             "<object-id-001>".to_string(),
             "<object-id-002>".to_string(),
@@ -612,8 +613,8 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
         ],
         meta_object_ids: vec!["<object-id-004>".to_string()],
         labels: vec![KeyValue {
-            key: "LabelKey".to_string(),
-            value: "LabelValue".to_string(),
+            key: "isDummyGroup".to_string(),
+            value: "true".to_string(),
         }],
         hooks: vec![],
     };
@@ -706,7 +707,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
 === "Bash"
 
     ```bash
-    # Native JSON request to delete ObjectGroup with all its revisions
+    # Native JSON request to delete an ObjectGroup revision
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<object-group-id>
@@ -715,7 +716,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
 === "Rust"
 
     ```rust
-    // Create tonic/ArunaAPI request to create a new object group
+    // Create tonic/ArunaAPI request to delete an ObjectGroup revision
     let delete_request = DeleteObjectGroupRequest {
         group_id: "<object-group-id>".to_string(),
         collection_id: "<collection-id>".to_string(),

--- a/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
+++ b/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
@@ -78,6 +78,31 @@ API example for creating an ObjectGroup.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to create a new object group
+    request = CreateObjectGroupRequest(
+        name="Python-API-Test-ObjectGroup",
+        description="This object group was created with the gRPC Python API client.",
+        collection_id="<collection-id>",
+        object_ids=["<object-id-001>",
+                    "<object-id-002>",
+                    "<object-id-003>"],
+        meta_object_ids=["<object-id-004>"],
+        labels=[KeyValue(
+            key="isDummyGroup",
+            value="true"
+        )],
+        hooks=None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.CreateObjectGroup(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
 
 ## Get ObjectGroup
 
@@ -196,6 +221,73 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information about a specific object group
+    request = GetObjectGroupByIdRequest(
+        group_id="<object-group-id>",
+        collection_id="<collection-id>"
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroupById(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information about the first 20 revisions of an object group
+    request = GetObjectGroupHistoryRequest(
+        collection_id="<collection-id>",
+        group_id="<object-group-id>",
+        page_request=None  # Parameter can also be omitted if None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroupHistory(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information about the first 250 revisions of an object group
+    request = GetObjectGroupHistoryRequest(
+        collection_id="<collection-id>",
+        group_id="<object-group-id>",
+        page_request=PageRequest(
+            last_uuid="",  # Parameter can also be omitted if empty
+            page_size=250
+        )
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroupHistory(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information about the revisions 21-40 (i.e. next page) of an object group
+    request = GetObjectGroupHistoryRequest(
+        collection_id="<collection-id>",
+        group_id="<object-group-id>",
+        page_request=PageRequest(
+            last_uuid="<last-received-object-group-id>",  
+            page_size=0  # Parameter can also be omitted if <= 0 (Defaults to 20)
+        )
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroupHistory(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Get all ObjectGroups of Collection
 
@@ -232,6 +324,23 @@ You can also fetch all ObjectGroups of a Collection at once.
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information about the first 20 object groups of a collection
+    request = GetObjectGroupsRequest(
+        collection_id="<collection-id>",
+        page_request=None,
+        label_id_filter=None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroups(request=request)
+
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -328,6 +437,59 @@ There is also the possibility to only fetch the objects marked as metadata of th
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of the first 20 objects of an object group including meta objects
+    request = GetObjectGroupObjectsRequest(
+        collection_id="<collection-id>",
+        group_id="<object-group-id>",
+        page_request=None,
+        meta_only=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroupObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to fetch information of the first 250 objects of an object group including meta objects
+    request = GetObjectGroupObjectsRequest(
+        collection_id="<collection-id>",
+        group_id="<object-group-id>",
+        page_request=PageRequest(
+            last_uuid="",
+            page_size=250
+        ),
+        meta_only=False
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroupObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to to fetch information only of meta objects of an object group
+    request = GetObjectGroupObjectsRequest(
+        collection_id="<collection-id>",
+        group_id="<object-group-id>",
+        page_request=None,
+        meta_only=True
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.GetObjectGroupObjects(request=request)
+
+    # Do something with the response
+    print(f'{response}')
     ```
 
 
@@ -466,6 +628,58 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
     println!("{:#?}", response);
     ```
 
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to update the description of an object group
+    request = UpdateObjectGroupRequest(
+        group_id="<object-group-id>",
+        name="Python-API-Test-ObjectGroup",
+        description="This object group was updated with the gRPC Python API client.",
+        collection_id="<collection-id>",
+        object_ids=["<object-id-001>",
+                    "<object-id-002>",
+                    "<object-id-003>"],
+        meta_object_ids=["<object-id-004>"],
+        labels=[KeyValue(
+            key="isDummyGroup",
+            value="true"
+        )],
+        hooks=None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.UpdateObjectGroup(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+    ```python
+    # Create tonic/ArunaAPI request to update the description of an object group
+    request = UpdateObjectGroupRequest(
+        group_id="<object-group-id>",
+        name="Python-API-Test-ObjectGroup",
+        description="This object group was updated with the gRPC Python API client.",
+        collection_id="<collection-id>",
+        object_ids=["<object-id-001>",
+                    "<object-id-002>",
+                    "<object-id-005>"],
+        meta_object_ids=["<object-id-004>"],
+        labels=[KeyValue(
+            key="isDummyGroup",
+            value="true"
+        )],
+        hooks=None
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.UpdateObjectGroup(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
 
 ## Delete ObjectGroup
 
@@ -515,4 +729,20 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
     
     // Do something with the response
     println!("{:#?}", response);
+    ```
+
+=== "Python"
+
+    ```python
+    # Create tonic/ArunaAPI request to delete an ObjectGroup revision
+    request = DeleteObjectGroupRequest(
+        group_id="<object-group-id>",
+        collection_id="<collection-id>"
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.DeleteObjectGroup(request=request)
+
+    # Do something with the response
+    print(f'{response}')
     ```

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,6 +1,7 @@
 :root > * {
   --md-primary-fg-color: #165a97;
-  --md-accent-fg-color: eaf7ff;
+  --md-accent-fg-color: #165a97;
+  --md-tooltip-width: 600px;
 }
 
 .md-grid {

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -27,6 +27,7 @@ theme:
   logo: assets/logo-claim.png
   favicon: assets/logo-icon.png
   features:
+    - content.code.annotate
     - navigation.tabs
     - navigation.sections  # Sections are included in the navigation on the left.
     - toc.integrate


### PR DESCRIPTION
This extends the ` Get Started` section with examples for the basic usage of the Python API gRPC client.

## Changes

* Add Python API gRPC client initialization in simple and extensive version
* Add Python API gRPC client examples for all resources
* Cleanup of minor layout mistakes, spelling errors, etc.

These changes are related to a subtask of https://github.com/ArunaStorage/ArunaServer/issues/15.