### PR TITLE
Extend code block display

### DIFF
--- a/docs/get_started/basic_usage/01_Get-Storage-Access.md
+++ b/docs/get_started/basic_usage/01_Get-Storage-Access.md
@@ -22,7 +22,9 @@ The presence of a client connection to the specific resource service is required
 
     These are minimal reproducible examples only for demonstration purposes which should not be used 'as-is' in a production environment!
 
-=== "Rust"
+=== ":simple-rust: Rust"
+
+    To use the Rust API library you have to set it as dependency `aruna-rust-api = "<Aruna-Rust-API-Version>"` in the `cargo.toml` of your project.
 
     ```rust
     use aruna_rust_api::api::aruna::api::storage::services::v1::{
@@ -76,7 +78,7 @@ The presence of a client connection to the specific resource service is required
     }
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     To use the Python API library in your Python project you have to install the PyPI package: `pip install Aruna-Python-API`.
 
@@ -163,7 +165,7 @@ The presence of a client connection to the specific resource service is required
         # Do something with the client services ...
     ```
 
-=== "Python (simple)"
+=== ":simple-python: Python (simple)"
 
     To use the Python API library in your Python project you have to install the PyPI package: `pip install Aruna-Python-API`.
 
@@ -222,7 +224,7 @@ The presence of a client connection to the specific resource service is required
 
 Users can register themselves with an individual display name in an AOS instance with their valid OIDC token received from the AAI login.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to register OIDC user
@@ -235,7 +237,7 @@ Users can register themselves with an individual display name in an AOS instance
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/auth/register
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to register OIDC user
@@ -253,7 +255,7 @@ Users can register themselves with an individual display name in an AOS instance
     println!("Registered user: {:#?}", response.user_id)
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to register OIDC user
@@ -280,7 +282,7 @@ Users can register themselves with an individual display name in an AOS instance
 
 After registration users additionally have to be activated in a second step.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # For convenience, administrators can request info on all unactivated users at once
@@ -297,7 +299,7 @@ After registration users additionally have to be activated in a second step.
     ```
 
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch all not activated users
@@ -331,7 +333,7 @@ After registration users additionally have to be activated in a second step.
     println!("Activated user: {:#?}", activate_response.user_id)
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request for user activation
@@ -355,7 +357,7 @@ To check which user a token is associated with or get information about the curr
 
     Only AOS instance administrators can request user information of other users.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch user information associated with authorization token
@@ -371,7 +373,7 @@ To check which user a token is associated with or get information about the curr
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/user?userId=<user-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch user info of current user
@@ -393,7 +395,7 @@ To check which user a token is associated with or get information about the curr
     }
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch user info of current user

--- a/docs/get_started/basic_usage/01_Get-Storage-Access.md
+++ b/docs/get_started/basic_usage/01_Get-Storage-Access.md
@@ -26,7 +26,7 @@ The presence of a client connection to the specific resource service is required
 
     To use the Rust API library you have to set it as dependency `aruna-rust-api = "<Aruna-Rust-API-Version>"` in the `cargo.toml` of your project.
 
-    ```rust
+    ```rust linenums="1"
     use aruna_rust_api::api::aruna::api::storage::services::v1::{
         user_service_client,
         project_service_client,
@@ -90,7 +90,7 @@ The presence of a client connection to the specific resource service is required
 
         **All Python examples in this documentation assume that the client services have been initialized with an interceptor.**
 
-    ```python
+    ```python linenums="1"
     import collections
     import grpc
     
@@ -177,7 +177,7 @@ The presence of a client connection to the specific resource service is required
 
         **All Python examples in this documentation assume that the client services have been initialized with an interceptor.**
 
-    ```python
+    ```python linenums="1"
     import grpc
 
     from aruna.api.storage.services.v1.collection_service_pb2_grpc import CollectionServiceStub
@@ -226,7 +226,7 @@ Users can register themselves with an individual display name in an AOS instance
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to register OIDC user
     curl -d '
       {
@@ -239,7 +239,7 @@ Users can register themselves with an individual display name in an AOS instance
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to register OIDC user
     let register_request = RegisterUserRequest {
         display_name: "John Doe".to_string(),
@@ -257,7 +257,7 @@ Users can register themselves with an individual display name in an AOS instance
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to register OIDC user
     request = RegisterUserRequest(
         display_name="John Doe"
@@ -284,14 +284,14 @@ After registration users additionally have to be activated in a second step.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # For convenience, administrators can request info on all unactivated users at once
     curl -H "Authorization: Bearer <API-Or-OIDC_TOKEN>" \
          -H "Content-Type: application/json" \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/user/not_activated
     ```
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to activate registered user
     curl -H "Authorization: Bearer <API-Or-OIDC_TOKEN>" \
          -H "Content-Type: application/json" \
@@ -301,7 +301,7 @@ After registration users additionally have to be activated in a second step.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch all not activated users
     let get_request = GetNotActivatedUsersRequest {};
     
@@ -315,7 +315,7 @@ After registration users additionally have to be activated in a second step.
     println!("{:#?}", unactivated);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request for user activation
     let user_id = uuid::Uuid::parse("12345678-1234-1234-1234-123456789999").unwrap();
     
@@ -335,7 +335,7 @@ After registration users additionally have to be activated in a second step.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request for user activation
     request = ActivateUserRequest(
         user_id="<user-id>"  # Has to be a valid UUID v4 of a registered user
@@ -359,14 +359,14 @@ To check which user a token is associated with or get information about the curr
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch user information associated with authorization token
     curl -H "Authorization: Bearer <API-Or-OIDC_TOKEN>" \
          -H "Content-Type: application/json" \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/user
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch user information associated with the provided user id
     curl -H "Authorization: Bearer <API-Or-OIDC_TOKEN>" \
          -H "Content-Type: application/json" \
@@ -375,7 +375,7 @@ To check which user a token is associated with or get information about the curr
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch user info of current user
     let get_request = GetUserRequest {
         user_id: "".to_string()
@@ -397,7 +397,7 @@ To check which user a token is associated with or get information about the curr
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch user info of current user
     request = GetUserRequest()
     

--- a/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
+++ b/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
@@ -56,7 +56,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
 
     This request needs at least ADMIN permissions on the specific Project.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to add user with admin permissions to a project
@@ -89,7 +89,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/project/<project-id>/add_user
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to add user with admin permissions to a project
@@ -135,7 +135,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to add user with admin permissions to a project
@@ -182,7 +182,7 @@ The assigned permissions to the users can be changed by project administrators a
 
     This request needs at least ADMIN permissions on the specific Project.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to set a users permission to read only for the specific project
@@ -199,7 +199,7 @@ The assigned permissions to the users can be changed by project administrators a
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/project/<project-id>/edit_user
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to set a users permission to read only for the specific project
@@ -223,7 +223,7 @@ The assigned permissions to the users can be changed by project administrators a
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to set a users permission to read only for the specific project
@@ -254,7 +254,7 @@ However, access with project/collection scoped tokens is not restricted with the
 
     This request needs at least ADMIN permissions on the specific Project.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to remove a user from a specific project
@@ -263,7 +263,7 @@ However, access with project/collection scoped tokens is not restricted with the
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/project/<project-id>/remove_user?userId=<user-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to remove a user from a specific project
@@ -282,7 +282,7 @@ However, access with project/collection scoped tokens is not restricted with the
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to remove a user from a specific project
@@ -310,7 +310,7 @@ Here are some API examples on generating API tokens with individual scopes and p
     Store the received token secret in a secure location for further usage.
     If a token secret is lost or compromised, delete the old token and generate a new one.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to create a global/personal token
@@ -363,7 +363,7 @@ Here are some API examples on generating API tokens with individual scopes and p
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/auth/token
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     The "in-line" conversion of a NativeDateTime to a gRPC Timestamp is kind of hacky.
     
@@ -401,7 +401,7 @@ Here are some API examples on generating API tokens with individual scopes and p
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to create a global/personal API token with expiration date
@@ -465,7 +465,7 @@ API examples to fetch info of a specific token or all tokens of the current user
 
     This request does not re-display the generated API token secret. See [Generate API Tokens](#generate-api-tokens).
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to get info on a specific API token by its id
@@ -481,7 +481,7 @@ API examples to fetch info of a specific token or all tokens of the current user
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/auth/tokens
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to get info on a specific API token by its id
@@ -513,7 +513,7 @@ API examples to fetch info of a specific token or all tokens of the current user
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to get info on a specific API token by its id
@@ -548,7 +548,7 @@ API examples to revoke/delete a specific API token or all tokens of the current 
 
     Only AOS instance administrators can revoke API tokens of other users.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to revoke the specific API token
@@ -564,7 +564,7 @@ API examples to revoke/delete a specific API token or all tokens of the current 
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/auth/tokens
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to revoke the specific API token
@@ -598,7 +598,7 @@ API examples to revoke/delete a specific API token or all tokens of the current 
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to revoke the specific API token

--- a/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
+++ b/docs/get_started/basic_usage/02_How-To-Auth-Tokens.md
@@ -58,7 +58,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to add user with admin permissions to a project
     curl -d '
       {
@@ -73,7 +73,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/project/<project-id>/add_user
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to add user with read only permissions to a project
     curl -d '
       {
@@ -91,7 +91,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to add user with admin permissions to a project
     let add_request = AddUserToProjectRequest {
         project_id: "<project-id>".to_string(),
@@ -113,7 +113,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to add user with read only permissions to a project
     let add_request = AddUserToProjectRequest {
         project_id: "<project-id>".to_string(),
@@ -137,7 +137,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to add user with admin permissions to a project
     request = AddUserToProjectRequest(
         project_id="<project-id>",
@@ -155,7 +155,7 @@ It also makes it easy to restrict or extend a user's permissions for a project w
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to add user with read only permissions to a project
     request = AddUserToProjectRequest(
         project_id="<project-id>",
@@ -184,7 +184,7 @@ The assigned permissions to the users can be changed by project administrators a
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to set a users permission to read only for the specific project
     curl -d '
       {
@@ -201,7 +201,7 @@ The assigned permissions to the users can be changed by project administrators a
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to set a users permission to read only for the specific project
     let edit_request = EditUserPermissionsForProjectRequest {
         project_id: "<project-id>".to_string(),
@@ -225,7 +225,7 @@ The assigned permissions to the users can be changed by project administrators a
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to set a users permission to read only for the specific project
     request = EditUserPermissionsForProjectRequest(
         project_id="<project-id>",
@@ -256,7 +256,7 @@ However, access with project/collection scoped tokens is not restricted with the
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to remove a user from a specific project
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -265,7 +265,7 @@ However, access with project/collection scoped tokens is not restricted with the
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to remove a user from a specific project
     let delete_request = RemoveUserFromProjectRequest {
         project_id: "<project-id>".to_string(),
@@ -284,7 +284,7 @@ However, access with project/collection scoped tokens is not restricted with the
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to remove a user from a specific project
     request = RemoveUserFromProjectRequest(
         project_id="<project-id>",
@@ -312,7 +312,7 @@ Here are some API examples on generating API tokens with individual scopes and p
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a global/personal token
     #  This token inherits the permissions from the projects the user is a member of
     curl -d '
@@ -329,7 +329,7 @@ Here are some API examples on generating API tokens with individual scopes and p
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/auth/token
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a project scoped token with MODIFY permissions
     curl -d '
       {
@@ -346,7 +346,7 @@ Here are some API examples on generating API tokens with individual scopes and p
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/auth/token
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a collection scoped token with READ permissions
     curl -d '
       {
@@ -369,7 +369,7 @@ Here are some API examples on generating API tokens with individual scopes and p
     
     In any case it is recommended to implement the `From<NativeDateTime>` or `TryFrom<NativeDateTime>` trait for the Timestamp Struct.
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to create a global/personal API token with expiration date
     let expires_at = NaiveDate::from_ymd(2023, 01, 01).and_hms(0, 0, 0);
     let create_request = CreateApiTokenRequest {
@@ -403,7 +403,7 @@ Here are some API examples on generating API tokens with individual scopes and p
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a global/personal API token with expiration date
     request = CreateAPITokenRequest(
         project_id="",  # Parameter can also be omitted if empty
@@ -422,7 +422,7 @@ Here are some API examples on generating API tokens with individual scopes and p
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a project scoped API token with MODIFY permission
     request = CreateAPITokenRequest(
         project_id="<project-id>",
@@ -439,7 +439,7 @@ Here are some API examples on generating API tokens with individual scopes and p
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a collection scoped API token with APPEND permission
     request = CreateAPITokenRequest(
         project_id="",  # Parameter can also be omitted if empty
@@ -467,14 +467,14 @@ API examples to fetch info of a specific token or all tokens of the current user
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to get info on a specific API token by its id
     curl -H 'Authorization: Bearer <OIDC-Or-API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/auth/token/{token-id}
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to get info on all tokens associated with the current user
     curl -H 'Authorization: Bearer <OIDC-Or-API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -483,7 +483,7 @@ API examples to fetch info of a specific token or all tokens of the current user
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to get info on a specific API token by its id
     let get_request = GetApiTokenRequest { 
         token_id: "<token-id>".to_string(),
@@ -499,7 +499,7 @@ API examples to fetch info of a specific token or all tokens of the current user
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to get info on all tokens associated with the current user
     let get_request = GetApiTokensRequest {};
     
@@ -515,7 +515,7 @@ API examples to fetch info of a specific token or all tokens of the current user
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to get info on a specific API token by its id
     request = GetAPITokenRequest(
         token_id="<token-id>"
@@ -528,7 +528,7 @@ API examples to fetch info of a specific token or all tokens of the current user
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to get info on all tokens associated with the current user
     request = GetAPITokensRequest()
     
@@ -550,14 +550,14 @@ API examples to revoke/delete a specific API token or all tokens of the current 
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to revoke the specific API token
     curl -H 'Authorization: Bearer <OIDC-Or-API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/auth/token/{token-id}
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to revoke all tokens of the current user
     curl -H 'Authorization: Bearer <OIDC-Or-API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -566,7 +566,7 @@ API examples to revoke/delete a specific API token or all tokens of the current 
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to revoke the specific API token
     let delete_request = DeleteApiTokenRequest {
         token_id: "<token-id>".to_string(),
@@ -582,7 +582,7 @@ API examples to revoke/delete a specific API token or all tokens of the current 
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to to revoke all tokens of the current user
     let delete_request = DeleteApiTokensRequest {
         user_id: "".to_string(),
@@ -600,7 +600,7 @@ API examples to revoke/delete a specific API token or all tokens of the current 
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to revoke the specific API token
     request = DeleteAPITokenRequest(
         token_id="<token-id>"
@@ -613,7 +613,7 @@ API examples to revoke/delete a specific API token or all tokens of the current 
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to to revoke all tokens of the current user
     request = DeleteAPITokensRequest()
     

--- a/docs/get_started/basic_usage/03_How-To-Project.md
+++ b/docs/get_started/basic_usage/03_How-To-Project.md
@@ -18,7 +18,7 @@ API example for creating a new Project.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a project
     curl -d '
       {
@@ -32,7 +32,7 @@ API example for creating a new Project.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to create a project
     let create_request = CreateProjectRequest {
         name: "Rust-API-Test-Project".to_string(),
@@ -51,7 +51,7 @@ API example for creating a new Project.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a project
     request = CreateProjectRequest(
         name="Python-API-Test-Project",
@@ -76,7 +76,7 @@ API example for fetching info of an existing Project.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of a project
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -85,7 +85,7 @@ API example for fetching info of an existing Project.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information of a project
     let get_request = GetProjectRequest { 
         project_id: "<project-id>".to_string(),
@@ -103,7 +103,7 @@ API example for fetching info of an existing Project.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of a project
     request = GetProjectRequest(
         project_id="<project-id>"
@@ -127,7 +127,7 @@ API example for fetching all registered Projects a specific user is associated w
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of all projects a specific user is member of
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -136,7 +136,7 @@ API example for fetching all registered Projects a specific user is associated w
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information of all projects a specific user is member of
     let get_request = GetUserProjectsRequest {
         user_id: "".to_string(),
@@ -154,7 +154,7 @@ API example for fetching all registered Projects a specific user is associated w
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of all projects a specific user is member of
     request = GetUserProjectsRequest(
         user_id=""  # Parameter can be omitted if empty
@@ -183,7 +183,7 @@ API example for updating an existing Project.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to update the metadata of a project
     curl -d '
       {
@@ -197,7 +197,7 @@ API example for updating an existing Project.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to update the metadata of a project
     let update_request = UpdateProjectRequest {
         project_id: "<project-id>".to_string(),
@@ -217,7 +217,7 @@ API example for updating an existing Project.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to update the metadata of a project
     request = UpdateProjectRequest(
         project_id="<project-id>",
@@ -248,7 +248,7 @@ API examples for deleting a Project.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to delete a project
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -257,7 +257,7 @@ API examples for deleting a Project.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to delete a project
     let delete_request = DestroyProjectRequest {
         project_id: "<project-id>".to_string(),
@@ -275,7 +275,7 @@ API examples for deleting a Project.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to delete a project
     request = DestroyProjectRequest(
         project_id="<project-id>"

--- a/docs/get_started/basic_usage/03_How-To-Project.md
+++ b/docs/get_started/basic_usage/03_How-To-Project.md
@@ -16,7 +16,7 @@ API example for creating a new Project.
 
     Currently, to create a new Project you have to be an AOS instance administrator.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to create a project
@@ -30,7 +30,7 @@ API example for creating a new Project.
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/project
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to create a project
@@ -49,7 +49,7 @@ API example for creating a new Project.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to create a project
@@ -74,7 +74,7 @@ API example for fetching info of an existing Project.
 
     This request needs at least READ permissions on the specific Project.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information of a project
@@ -83,7 +83,7 @@ API example for fetching info of an existing Project.
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/project/{project-id}
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch information of a project
@@ -101,7 +101,7 @@ API example for fetching info of an existing Project.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch information of a project
@@ -125,7 +125,7 @@ API example for fetching all registered Projects a specific user is associated w
 
     You have to be an AOS instance administrator to fetch all registered Projects associated with other users than yourself.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information of all projects a specific user is member of
@@ -134,7 +134,7 @@ API example for fetching all registered Projects a specific user is associated w
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/user/{user-id}/projects
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch information of all projects a specific user is member of
@@ -152,7 +152,7 @@ API example for fetching all registered Projects a specific user is associated w
     println!("{:#?}\n", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch information of all projects a specific user is member of
@@ -181,7 +181,7 @@ API example for updating an existing Project.
     **A project update overwrites all the fields in the request, even if they're empty. 
     If you want to retain a field you have to explicitly set the old value.**
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to update the metadata of a project
@@ -195,7 +195,7 @@ API example for updating an existing Project.
          -X PUT https://<URL-to-AOS-instance-API-gateway>/v1/project/{project-id}
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to update the metadata of a project
@@ -215,7 +215,7 @@ API example for updating an existing Project.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to update the metadata of a project
@@ -246,7 +246,7 @@ API examples for deleting a Project.
 
     This request needs at least ADMIN permissions on the specific Project.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to delete a project
@@ -255,7 +255,7 @@ API examples for deleting a Project.
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/project/{project-id}
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to delete a project
@@ -273,7 +273,7 @@ API examples for deleting a Project.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to delete a project

--- a/docs/get_started/basic_usage/04_How-To-Collections.md
+++ b/docs/get_started/basic_usage/04_How-To-Collections.md
@@ -19,7 +19,7 @@ API example for creating a new Collection.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a new collection
     curl -d '
       {
@@ -52,7 +52,7 @@ API example for creating a new Collection.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to create a new collection
     let create_request = CreateNewCollectionRequest {
         name: "Rust-API-Test-Collection".to_string(),
@@ -84,7 +84,7 @@ API example for creating a new Collection.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a new collection
     request = CreateNewCollectionRequest(
         name="Python-API-Test-Collection",
@@ -120,14 +120,14 @@ API examples for fetching one or multiple existing Collection/s.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of a collection
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch multiple collections of a project
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -136,7 +136,7 @@ API examples for fetching one or multiple existing Collection/s.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information of a collection
     let get_request = GetCollectionByIdRequest {
         collection_id: "<collection-id>".to_string(),
@@ -152,7 +152,7 @@ API examples for fetching one or multiple existing Collection/s.
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch all collections of a project
     let get_request = GetCollectionsRequest {
         project_id: "<project-id>".to_string(),
@@ -170,7 +170,7 @@ API examples for fetching one or multiple existing Collection/s.
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by their ids
     let get_request = GetCollectionsRequest {
         project_id: "<project-id>".to_string(),
@@ -194,7 +194,7 @@ API examples for fetching one or multiple existing Collection/s.
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by label keys
     let get_request = GetCollectionsRequest {
         project_id: "<project-id>".to_string(),
@@ -224,7 +224,7 @@ API examples for fetching one or multiple existing Collection/s.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of a collection
     request = GetCollectionByIDRequest(
         collection_id="<collection-id>"
@@ -237,7 +237,7 @@ API examples for fetching one or multiple existing Collection/s.
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request fetch first 20 collections of a project
     request = GetCollectionsRequest(
         project_id="<project-id>",
@@ -252,7 +252,7 @@ API examples for fetching one or multiple existing Collection/s.
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by their ids
     GetCollectionsRequest(
         project_id="<project-id>",
@@ -271,7 +271,7 @@ API examples for fetching one or multiple existing Collection/s.
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch multiple collections of a project filtered by label keys
     request = GetCollectionsRequest(
         project_id="<project-id>",
@@ -315,7 +315,7 @@ API example for updating a Collection.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to update a collections name and description
     curl -d '
       {
@@ -348,7 +348,7 @@ API example for updating a Collection.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to update a collections name and description
     let update_request = UpdateCollectionRequest {
         collection_id: "<collection-id>".to_string(),
@@ -382,7 +382,7 @@ API example for updating a Collection.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to update a collections name and description
     request = UpdateCollectionRequest(
         project_id="<project-id>",
@@ -423,7 +423,7 @@ Pinned collections can not be updated in place anymore.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to pin a collection to a specific version
     curl -d '
       {
@@ -440,7 +440,7 @@ Pinned collections can not be updated in place anymore.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to pin a collection to a specific version
     let pin_request = PinCollectionVersionRequest {
         collection_id: "<collection-id>".to_string(),
@@ -463,7 +463,7 @@ Pinned collections can not be updated in place anymore.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to pin a collection to a specific version
     request = PinCollectionVersionRequest(
         collection_id="<collection-id>",
@@ -497,7 +497,7 @@ API examples for deleting a Collection.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to delete a collection
     curl -d '
       {
@@ -509,7 +509,7 @@ API examples for deleting a Collection.
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to force delete a collection with force
     curl -d '
       {
@@ -523,7 +523,7 @@ API examples for deleting a Collection.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to delete a collection
     let delete_request = DeleteCollectionRequest {
         collection_id: "<collection-id>".to_string(),
@@ -541,7 +541,7 @@ API examples for deleting a Collection.
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to delete a collection with force
     let delete_request = DeleteCollectionRequest {
         collection_id: "<collection-id>".to_string(),
@@ -561,7 +561,7 @@ API examples for deleting a Collection.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to delete a collection
     request = DeleteCollectionRequest(
         collection_id="<collection-id>",
@@ -576,7 +576,7 @@ API examples for deleting a Collection.
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to delete a collection with force
     request = DeleteCollectionRequest(
         collection_id="<collection-id>",

--- a/docs/get_started/basic_usage/04_How-To-Collections.md
+++ b/docs/get_started/basic_usage/04_How-To-Collections.md
@@ -17,7 +17,7 @@ API example for creating a new Collection.
 
     This request requires at least MODIFY permission on the Project in which the Collection is to be created.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to create a new collection
@@ -50,7 +50,7 @@ API example for creating a new Collection.
       -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to create a new collection
@@ -82,7 +82,7 @@ API example for creating a new Collection.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to create a new collection
@@ -118,7 +118,7 @@ API examples for fetching one or multiple existing Collection/s.
 
     This request needs at least READ permissions on the Collection or the Project under which the collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information of a collection
@@ -134,7 +134,7 @@ API examples for fetching one or multiple existing Collection/s.
          -X GET "https://<URL-to-AOS-instance-API-gateway>/v1/collections/<project-id>?labelOrIdFilter.ids=<collection-id-001>&labelOrIdFilter.ids=<collection-id-002>"
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch information of a collection
@@ -222,7 +222,7 @@ API examples for fetching one or multiple existing Collection/s.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch information of a collection
@@ -313,7 +313,7 @@ API example for updating a Collection.
 
     This request needs at least MODIFY permissions on the Collection or the Project under which the collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to update a collections name and description
@@ -346,7 +346,7 @@ API example for updating a Collection.
       -X PUT https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to update a collections name and description
@@ -380,7 +380,7 @@ API example for updating a Collection.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to update a collections name and description
@@ -421,7 +421,7 @@ Pinned collections can not be updated in place anymore.
 
     This request needs at least MODIFY permissions on the Collection or the Project under which the collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to pin a collection to a specific version
@@ -438,7 +438,7 @@ Pinned collections can not be updated in place anymore.
       -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/pin
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to pin a collection to a specific version
@@ -461,7 +461,7 @@ Pinned collections can not be updated in place anymore.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to pin a collection to a specific version
@@ -495,7 +495,7 @@ API examples for deleting a Collection.
 
     This request needs at least MODIFY permissions on the Collection or ADMIN permissions on the Project under which the collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to delete a collection
@@ -521,7 +521,7 @@ API examples for deleting a Collection.
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to delete a collection
@@ -559,7 +559,7 @@ API examples for deleting a Collection.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to delete a collection

--- a/docs/get_started/basic_usage/05_How-To-Objects.md
+++ b/docs/get_started/basic_usage/05_How-To-Objects.md
@@ -19,7 +19,7 @@ As long as an Object is in the staging area data can be uploaded to it.
 
     This request needs at least APPEND permissions on the Object's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to initialize an staging object
@@ -48,7 +48,7 @@ As long as an Object is in the staging area data can be uploaded to it.
       -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to initialize an staging object
@@ -85,7 +85,7 @@ As long as an Object is in the staging area data can be uploaded to it.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to initialize an staging object
@@ -134,7 +134,7 @@ You also have to request an upload url for each part individually.
 
 ### Single part upload
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to request an upload url for single part upload
@@ -146,7 +146,7 @@ You also have to request an upload url for each part individually.
     curl -X PUT -T <path-to-local-file> <upload-url>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to request an upload url for single part upload
@@ -187,7 +187,7 @@ You also have to request an upload url for each part individually.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to request an upload url for single part upload
@@ -232,7 +232,7 @@ You also have to request an upload url for each part individually.
 
     **If the data is stored in an S3 endpoint individual parts of multipart upload have to be at least 5MiB in size (5242880 bytes) or the Object finishing will fail.**
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to request an upload url for specific part of multipart upload
@@ -244,7 +244,7 @@ You also have to request an upload url for each part individually.
     curl -X PUT -T <path-to-local-file> <upload-url>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI to request an upload url for specific part of multipart upload
@@ -266,7 +266,7 @@ You also have to request an upload url for each part individually.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to request an upload url for specific part of multipart upload
@@ -288,7 +288,7 @@ You also have to request an upload url for each part individually.
 
 ##### Multipart upload example
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     COLLECTION_ID=<collection-id>
@@ -311,7 +311,7 @@ You also have to request an upload url for each part individually.
     done
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     let mut file = tokio::fs::File::open("/path/to/local/file").await.unwrap();     // File handle
@@ -372,7 +372,7 @@ You also have to request an upload url for each part individually.
     println!("{:#?}", completed_parts);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     CHUNK_SIZE = 1024 * 1024 * 50;  # 50MiB chunks
@@ -446,7 +446,7 @@ On success the response will contain all the information on the finished Object.
 
     This request needs at least APPEND permissions on the Object's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to finish a single upload staging object
@@ -491,7 +491,7 @@ On success the response will contain all the information on the finished Object.
          -X PATCH https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}/staging/{upload-id}/finish
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to finish a single part upload staging object
@@ -552,7 +552,7 @@ On success the response will contain all the information on the finished Object.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to finish a single part upload staging object
@@ -618,7 +618,7 @@ The `with_url` (or `withUrl`) parameter controls if the response includes a down
 
     This request needs at least READ permissions on the Object's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information of an object by its unique id
@@ -634,7 +634,7 @@ The `with_url` (or `withUrl`) parameter controls if the response includes a down
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}?withUrl=true
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch information of an object
@@ -654,7 +654,7 @@ The `with_url` (or `withUrl`) parameter controls if the response includes a down
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to to fetch information of an object
@@ -685,7 +685,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
 
     This request needs at least READ permissions on the Object's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information of the first 20 unfiltered objects in a collection
@@ -715,7 +715,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/objects?labelIdFilter.ids=<object-id-001>&labelIdFilter.ids=<object-id-002>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI to fetch information of the first 20 unfiltered objects in a collection
@@ -836,7 +836,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch information of the first 20 unfiltered objects in a collection
@@ -946,7 +946,7 @@ This can be done with an individual request or directly while getting informatio
 
     This request needs at least READ permissions on the Object's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch an Objects download url
@@ -968,7 +968,7 @@ This can be done with an individual request or directly while getting informatio
     curl -J -O -X GET <received-download-url>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Send GET request to download url
@@ -1001,7 +1001,7 @@ This can be done with an individual request or directly while getting informatio
     copy(&mut content, &mut target_file).unwrap();
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch an Objects download url
@@ -1048,7 +1048,7 @@ Objects can still be updated after finishing.
 
 Just adding one or multiple labels to an Object does not create a new revision.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to add a label to an object
@@ -1066,7 +1066,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
          -X PATCH https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}/add_labels
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to add a label to an object
@@ -1089,7 +1089,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to add a label to an object
@@ -1123,7 +1123,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 #### Update without data re-upload
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to update an objects description
@@ -1168,7 +1168,7 @@ Comparable to the Object initialization process, the updated Object must be fini
          -X PATCH https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}/staging/{upload-id}/finish
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to update an objects description
@@ -1231,7 +1231,7 @@ Comparable to the Object initialization process, the updated Object must be fini
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to update an objects description
@@ -1290,7 +1290,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 #### Update with data re-upload
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to update an Objects description as well as re-upload the data
@@ -1343,7 +1343,7 @@ Comparable to the Object initialization process, the updated Object must be fini
          -X PATCH https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}/staging/{upload-id}/finish
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to update an objects description as well as re-upload the data
@@ -1447,7 +1447,7 @@ Comparable to the Object initialization process, the updated Object must be fini
     println!("{:#?}", finish_response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to update an objects description as well as re-upload the data
@@ -1547,7 +1547,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
 
     Additionally, the request needs MODIFY permissions on the target Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to create an auto-updated read-only reference to keep track of an object
@@ -1573,7 +1573,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection/<source-collection-id>/object/<object-id>/reference/<destination-collection-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to create an auto-updated read-only reference to keep track of an object
@@ -1615,7 +1615,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to create an auto-updated read-only reference to keep track of an object
@@ -1662,7 +1662,7 @@ This process consists of two steps:
 1. Create writeable reference of the Object in another Collection
 2. Delete reference of the Object in the source Collection
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to create a writeable reference in another collection
@@ -1686,7 +1686,7 @@ This process consists of two steps:
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<source-collection-id>/object/<source-object-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to create a writeable reference in another collection
@@ -1725,7 +1725,7 @@ This process consists of two steps:
     println!("{:#?}", delete_response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to create a writeable reference in another collection
@@ -1767,7 +1767,7 @@ You can fetch information of all references an Object has in different Collectio
 
     This request needs at least READ permissions on the Object's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch all references of an object
@@ -1776,7 +1776,7 @@ You can fetch information of all references an Object has in different Collectio
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/object/<object-id>/references
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch all references of an object
@@ -1796,7 +1796,7 @@ You can fetch information of all references an Object has in different Collectio
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to
@@ -1840,7 +1840,7 @@ Permanent deletion conditions:
 
     **Non-writeable references will also be deleted alongside with the last writeable reference.**
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to force delete an object with all its revisions
@@ -1854,7 +1854,7 @@ Permanent deletion conditions:
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/object/<object-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to delete an object with all its revisions
@@ -1875,7 +1875,7 @@ Permanent deletion conditions:
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     # Create tonic/ArunaAPI request to delete an object with all its revisions
     request = DeleteObjectRequest(

--- a/docs/get_started/basic_usage/05_How-To-Objects.md
+++ b/docs/get_started/basic_usage/05_How-To-Objects.md
@@ -21,7 +21,7 @@ As long as an Object is in the staging area data can be uploaded to it.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to initialize an staging object
     curl -d '
       {
@@ -50,7 +50,7 @@ As long as an Object is in the staging area data can be uploaded to it.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to initialize an staging object
     let init_request = InitializeNewObjectRequest {
         object: Some(StageObject {
@@ -87,7 +87,7 @@ As long as an Object is in the staging area data can be uploaded to it.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to initialize an staging object
     request = InitializeNewObjectRequest(
         object=StageObject(
@@ -136,7 +136,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to request an upload url for single part upload
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -148,7 +148,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to request an upload url for single part upload
     let get_request = GetUploadUrlRequest {
         object_id: "<object-id>".to_string(),
@@ -189,7 +189,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to request an upload url for single part upload
     request = GetUploadURLRequest(
         object_id="<object-id>",
@@ -234,7 +234,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to request an upload url for specific part of multipart upload
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -246,7 +246,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI to request an upload url for specific part of multipart upload
     let get_request = GetUploadUrlRequest {
         object_id: "<object-id>".to_string(),
@@ -268,7 +268,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to request an upload url for specific part of multipart upload
     request = GetUploadURLRequest(
         object_id="<object-id>",
@@ -290,7 +290,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     COLLECTION_ID=<collection-id>
     OBJECT_ID=<staging-object-id>
     UPLOAD_ID=<objects-upload-id>
@@ -313,7 +313,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     let mut file = tokio::fs::File::open("/path/to/local/file").await.unwrap();     // File handle
     let mut remaining_bytes: usize = file.metadata().await.unwrap().len() as usize; // File size in bytes
     let mut upload_part_counter: i64 = 0; 
@@ -374,7 +374,7 @@ You also have to request an upload url for each part individually.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     CHUNK_SIZE = 1024 * 1024 * 50;  # 50MiB chunks
     
     file_path = "/path/to/local/file"
@@ -418,7 +418,7 @@ You also have to request an upload url for each part individually.
     ```
 
     1. **This function returns a generator with byte chunks of the specified file:**
-    ```python
+    ```python linenums="1"
         def read_file_chunks(file_object, chunk_size=5242880):
         """
         Generator to read set chunk sizes of a file object.
@@ -448,7 +448,7 @@ On success the response will contain all the information on the finished Object.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to finish a single upload staging object
     curl -d '
       {
@@ -465,7 +465,7 @@ On success the response will contain all the information on the finished Object.
          -X PATCH https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}/staging/{upload-id}/finish
     ```
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to finish a multipart upload staging object
     curl -d '
       {
@@ -493,7 +493,7 @@ On success the response will contain all the information on the finished Object.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to finish a single part upload staging object
     let finish_request = FinishObjectStagingRequest {
         object_id: "<object-id>".to_string(),
@@ -518,7 +518,7 @@ On success the response will contain all the information on the finished Object.
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to finish a multipart upload staging object
     let finish_request = FinishObjectStagingRequest {
         object_id: "<object-id>".to_string(),
@@ -554,7 +554,7 @@ On success the response will contain all the information on the finished Object.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to finish a single part upload staging object
     request = FinishObjectStagingRequest(
         object_id="<object-id>",
@@ -576,7 +576,7 @@ On success the response will contain all the information on the finished Object.
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to finish a multipart upload staging object
     finish_request = FinishObjectStagingRequest(
         object_id="<object-id>",
@@ -620,14 +620,14 @@ The `with_url` (or `withUrl`) parameter controls if the response includes a down
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of an object by its unique id
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/object/{object-id}
     ```
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of an object by its unique id including a download url
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -636,7 +636,7 @@ The `with_url` (or `withUrl`) parameter controls if the response includes a down
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information of an object
     let get_request = GetObjectByIdRequest {
         collection_id: "<collection-id>".to_string(),
@@ -656,7 +656,7 @@ The `with_url` (or `withUrl`) parameter controls if the response includes a down
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to to fetch information of an object
     request = GetObjectByIDRequest(
         object_id="<object-id>",
@@ -687,28 +687,28 @@ Additionally, you can include id or label filters to narrow the returned Objects
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of the first 20 unfiltered objects in a collection
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/objects
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of the first 250 unfiltered objects in a collection
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/objects?pageRequest.pageSize=250
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of the objects 21-40 (i.e. the next page) in a collection
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection-id}/objects?pageRequest.lastUuid=<id-of-last-received-object>
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of all objects in a collection matching one of the provided ids
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -717,7 +717,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI to fetch information of the first 20 unfiltered objects in a collection
     let get_request = GetObjectsRequest {
         collection_id: "<collection-id>".to_string(),
@@ -737,7 +737,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI to fetch information of the first 250 unfiltered objects in a collection
     let get_request = GetObjectsRequest {
         collection_id: "<collection-id>".to_string(),
@@ -760,7 +760,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI to fetch information of the objects 21-40 (i.e. the next page) in a collection
     let get_request = GetObjectsRequest {
         collection_id: "<collection-id>".to_string(),
@@ -783,7 +783,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI to fetch information of all objects in a collection matching one of the provided ids
     let get_request = GetObjectsRequest {
         collection_id: "<collection-id>".to_string(),
@@ -806,7 +806,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI to fetch multiple object of a collection filtered by label key(s)
     let get_request = GetObjectsRequest {
         collection_id: "<collection-id>".to_string(),
@@ -838,7 +838,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of the first 20 unfiltered objects in a collection
     request = GetObjectsRequest(
         collection_id="<collection-id>",
@@ -854,7 +854,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of the first 250 unfiltered objects in a collection
     request = GetObjectsRequest(
         collection_id="<collection-id>",
@@ -873,7 +873,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of the objects 21-40 (i.e. the next page) in a collection
     request = GetObjectsRequest(
         collection_id="<collection-id>",
@@ -892,7 +892,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of all objects in a collection matching one of the provided ids
     request = GetObjectsRequest(
         collection_id="<collection-id>",
@@ -911,7 +911,7 @@ Additionally, you can include id or label filters to narrow the returned Objects
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch multiple objects of a collection filtered by label key(s)
     request = GetObjectsRequest(
         collection_id="<collection-id>",
@@ -948,7 +948,7 @@ This can be done with an individual request or directly while getting informatio
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch an Objects download url
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -958,7 +958,7 @@ This can be done with an individual request or directly while getting informatio
     curl -J -O -X GET <received-download-url>
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of an Object including its download id
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -970,7 +970,7 @@ This can be done with an individual request or directly while getting informatio
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Send GET request to download url
     let response = reqwest::get(download_url).await.unwrap();
     
@@ -1003,7 +1003,7 @@ This can be done with an individual request or directly while getting informatio
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch an Objects download url
     download_url_request = GetDownloadURLRequest(
         collection_id="<collection-id>",
@@ -1050,7 +1050,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to add a label to an object
     curl -d '
       {
@@ -1068,7 +1068,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to add a label to an object
     let add_request = AddLabelToObjectRequest {
         object_id: "<object-id>".to_string(),
@@ -1091,7 +1091,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to add a label to an object
     request = AddLabelToObjectRequest(
         object_id="<object-id>",
@@ -1125,7 +1125,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to update an objects description
     curl -d '
       {
@@ -1170,7 +1170,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to update an objects description
     let update_request = UpdateObjectRequest {
         object_id: "<object-id>".to_string(),
@@ -1233,7 +1233,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to update an objects description
     update_request = UpdateObjectRequest(
         object_id="<object-id>",
@@ -1292,7 +1292,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to update an Objects description as well as re-upload the data
     curl -d '
       {
@@ -1345,7 +1345,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to update an objects description as well as re-upload the data
     let update_request = UpdateObjectRequest {
         object_id: "<object-id>".to_string(),
@@ -1449,7 +1449,7 @@ Comparable to the Object initialization process, the updated Object must be fini
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to update an objects description as well as re-upload the data
     update_request = UpdateObjectRequest(
         object_id="<object-id>",
@@ -1549,7 +1549,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create an auto-updated read-only reference to keep track of an object
     curl -d '
       {
@@ -1561,7 +1561,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection/<source-collection-id>/object/<object-id>/reference/<destination-collection-id>
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a writeable reference in another collection for collaborative work
     curl -d '
       {
@@ -1575,7 +1575,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to create an auto-updated read-only reference to keep track of an object
     let create_request = CreateObjectReferenceRequest {
         object_id: "<object-id>".to_string(),
@@ -1595,7 +1595,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
     println!("{:#?}", response);
     ```
     
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to create a writeable reference in another collection for collaborative work
     let create_request = CreateObjectReferenceRequest {
         object_id: "<object-id>".to_string(),
@@ -1617,7 +1617,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create an auto-updated read-only reference to keep track of an object
     request = CreateObjectReferenceRequest(
         object_id="<object-id>",
@@ -1634,7 +1634,7 @@ A reference can be either _"read only"_, which means that the Object can not be 
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a writeable reference in another collection for collaborative work
     request = CreateObjectReferenceRequest(
         object_id="<object-id>",
@@ -1664,7 +1664,7 @@ This process consists of two steps:
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a writeable reference in another collection
     curl -d '
       {
@@ -1688,7 +1688,7 @@ This process consists of two steps:
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to create a writeable reference in another collection
     let create_request = CreateObjectReferenceRequest {
         object_id: "<object-id>".to_string(),
@@ -1727,7 +1727,7 @@ This process consists of two steps:
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a writeable reference in another collection
     create_request = CreateObjectReferenceRequest(
         object_id="<object-id>",
@@ -1769,7 +1769,7 @@ You can fetch information of all references an Object has in different Collectio
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch all references of an object
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -1778,7 +1778,7 @@ You can fetch information of all references an Object has in different Collectio
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch all references of an object
     let get_request = GetReferencesRequest {
         object_id: "<object-id>".to_string(),
@@ -1798,7 +1798,7 @@ You can fetch information of all references an Object has in different Collectio
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to
     request = GetReferencesRequest(
         object_id="<object-id>",
@@ -1842,7 +1842,7 @@ Permanent deletion conditions:
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to force delete an object with all its revisions
     curl -d \
       '{
@@ -1856,7 +1856,7 @@ Permanent deletion conditions:
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to delete an object with all its revisions
     let delete_request = DeleteObjectRequest {
         object_id: "<object-id>".to_string(),
@@ -1877,6 +1877,7 @@ Permanent deletion conditions:
 
 === ":simple-python: Python"
 
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to delete an object with all its revisions
     request = DeleteObjectRequest(
         object_id="<source-object-id>",
@@ -1890,3 +1891,4 @@ Permanent deletion conditions:
     
     # Do something with the response
     print(f'{response}')
+    ```

--- a/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
+++ b/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
@@ -16,7 +16,7 @@ API example for creating an ObjectGroup.
 
     This request needs at least APPEND permissions on the ObjectGroup's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to create a new object group
@@ -45,7 +45,7 @@ API example for creating an ObjectGroup.
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to create a new object group
@@ -78,7 +78,7 @@ API example for creating an ObjectGroup.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to create a new object group
@@ -113,7 +113,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
 
     This request needs at least READ permissions on the ObjectGroup's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information about a specific object group
@@ -143,7 +143,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<group-id>/history?pageRequest.lastUuid=<last-received-object-group-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch information about a specific object group
@@ -222,7 +222,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch information about a specific object group
@@ -298,7 +298,7 @@ You can also fetch all ObjectGroups of a Collection at once.
 
     This request needs at least READ permissions on the ObjectGroup's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information about the first 20 object groups of a collection
@@ -307,7 +307,7 @@ You can also fetch all ObjectGroups of a Collection at once.
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch information about the first 20 object groups of a collection
@@ -327,7 +327,7 @@ You can also fetch all ObjectGroups of a Collection at once.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch information about the first 20 object groups of a collection
@@ -355,7 +355,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
 
     This request needs at least READ permissions on the ObjectGroup's Collection or the Project under which the Collection is registered.
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to fetch information of the first 20 objects of an object group including meta objects
@@ -378,7 +378,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<group-id>/objects?metaOnly=true
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to fetch information of the first 20 objects of an object group including meta objects
@@ -440,7 +440,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to fetch information of the first 20 objects of an object group including meta objects
@@ -511,7 +511,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
     **A object group update overwrites all the fields in the request, even if they're empty. 
     If you want to retain a field you have to explicitly set the old value.**
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to update the description of an object group
@@ -567,7 +567,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<object-group-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to update the description of an object group
@@ -629,7 +629,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to update the description of an object group
@@ -704,7 +704,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
 
     **ObjectGroup revisions can not be restored even if the revision still exists as DELETED.**
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     # Native JSON request to delete an ObjectGroup revision
@@ -713,7 +713,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
          -X DELETE https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<object-group-id>
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     // Create tonic/ArunaAPI request to delete an ObjectGroup revision
@@ -732,7 +732,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
     println!("{:#?}", response);
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     # Create tonic/ArunaAPI request to delete an ObjectGroup revision

--- a/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
+++ b/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
@@ -18,7 +18,7 @@ API example for creating an ObjectGroup.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to create a new object group
     curl -d '
       {
@@ -47,7 +47,7 @@ API example for creating an ObjectGroup.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to create a new object group
     let create_request = CreateObjectGroupRequest {
         name: "Rust-API-Test-ObjectGroup".to_string(),
@@ -80,7 +80,7 @@ API example for creating an ObjectGroup.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to create a new object group
     request = CreateObjectGroupRequest(
         name="Python-API-Test-ObjectGroup",
@@ -115,28 +115,28 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information about a specific object group
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<group-id>
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information about the first 20 revisions of an object group
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<group-id>/history
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information about the first 250 revisions of an object group
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<group-id>/history?pageRequest.pageSize=250
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information about the revisions 21-40 (i.e. next page) of an object group
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -145,7 +145,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information about a specific object group
     let get_request = GetObjectGroupByIdRequest { 
         group_id: "<object-group-id>".to_string(), 
@@ -162,7 +162,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information about the first 20 revisions of an object group
     let get_request = GetObjectGroupHistoryRequest {
         group_id: "<object-group-id>".to_string(),
@@ -180,7 +180,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information about the first 250 revisions of an object group
     let get_request = GetObjectGroupHistoryRequest {
         group_id: "<object-group-id>".to_string(),
@@ -201,7 +201,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information about the revisions 21-40 (i.e. next page) of an object group
     let get_request = GetObjectGroupHistoryRequest {
         group_id: "<object-group-id>".to_string(),
@@ -224,7 +224,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information about a specific object group
     request = GetObjectGroupByIdRequest(
         group_id="<object-group-id>",
@@ -238,7 +238,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information about the first 20 revisions of an object group
     request = GetObjectGroupHistoryRequest(
         collection_id="<collection-id>",
@@ -253,7 +253,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information about the first 250 revisions of an object group
     request = GetObjectGroupHistoryRequest(
         collection_id="<collection-id>",
@@ -271,7 +271,7 @@ Fetching information of an ObjectGroup only returns information of the ObjectGro
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information about the revisions 21-40 (i.e. next page) of an object group
     request = GetObjectGroupHistoryRequest(
         collection_id="<collection-id>",
@@ -300,7 +300,7 @@ You can also fetch all ObjectGroups of a Collection at once.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information about the first 20 object groups of a collection
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -309,7 +309,7 @@ You can also fetch all ObjectGroups of a Collection at once.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information about the first 20 object groups of a collection
     let get_request = GetObjectGroupsRequest {
         collection_id: "<collection-id>".to_string(),
@@ -329,7 +329,7 @@ You can also fetch all ObjectGroups of a Collection at once.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information about the first 20 object groups of a collection
     request = GetObjectGroupsRequest(
         collection_id="<collection-id>",
@@ -357,21 +357,21 @@ There is also the possibility to only fetch the objects marked as metadata of th
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of the first 20 objects of an object group including meta objects
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<group-id>/objects
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information of the first 250 objects of an object group including meta objects
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
          -X GET https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<group-id>/objects?pageRequest.pageSize=250
     ```
     
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to fetch information only of meta objects of an object group
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -380,7 +380,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information of the first 20 objects of an object group including meta objects
     let get_request = GetObjectGroupObjectsRequest {
         group_id: "<object-group-id>".to_string(),
@@ -399,7 +399,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information of the first 250 objects of an object group including meta objects
     let get_request = GetObjectGroupObjectsRequest {
         group_id: "<object-group-id>".to_string(),
@@ -421,7 +421,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to fetch information only of meta objects of an object group
     let get_request = GetObjectGroupObjectsRequest {
         group_id: "<object-group-id>".to_string(),
@@ -442,7 +442,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of the first 20 objects of an object group including meta objects
     request = GetObjectGroupObjectsRequest(
         collection_id="<collection-id>",
@@ -458,7 +458,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to fetch information of the first 250 objects of an object group including meta objects
     request = GetObjectGroupObjectsRequest(
         collection_id="<collection-id>",
@@ -477,7 +477,7 @@ There is also the possibility to only fetch the objects marked as metadata of th
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to to fetch information only of meta objects of an object group
     request = GetObjectGroupObjectsRequest(
         collection_id="<collection-id>",
@@ -513,7 +513,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to update the description of an object group
     curl -d '
       {
@@ -540,7 +540,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
          -X POST https://<URL-to-AOS-instance-API-gateway>/v1/collection/<collection-id>/group/<object-group-id>
     ```
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to update the description and objects contained in the object group
     curl -d '
       {
@@ -569,7 +569,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to update the description of an object group
     let update_request = UpdateObjectGroupRequest {
         group_id: "<object-group-id>".to_string(),
@@ -599,7 +599,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
     println!("{:#?}", response);
     ```
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to update the description and objects contained in the object group
     let update_request = UpdateObjectGroupRequest {
         group_id: "<object-group-id>".to_string(),
@@ -631,7 +631,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to update the description of an object group
     request = UpdateObjectGroupRequest(
         group_id="<object-group-id>",
@@ -656,7 +656,7 @@ Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
     print(f'{response}')
     ```
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to update the description of an object group
     request = UpdateObjectGroupRequest(
         group_id="<object-group-id>",
@@ -706,7 +706,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     # Native JSON request to delete an ObjectGroup revision
     curl -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -715,7 +715,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     // Create tonic/ArunaAPI request to delete an ObjectGroup revision
     let delete_request = DeleteObjectGroupRequest {
         group_id: "<object-group-id>".to_string(),
@@ -734,7 +734,7 @@ Deleted ObjectGroups are excluded from the general methods which fetch multiple 
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     # Create tonic/ArunaAPI request to delete an ObjectGroup revision
     request = DeleteObjectGroupRequest(
         group_id="<object-group-id>",

--- a/docs/get_started/basic_usage/07_How-To-EventNotification.md
+++ b/docs/get_started/basic_usage/07_How-To-EventNotification.md
@@ -13,17 +13,17 @@ After subscription, you will receive mail notifications if something happens wit
 
 > _Coming soon ..._
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     ```
@@ -33,17 +33,17 @@ After subscription, you will receive mail notifications if something happens wit
 
 > _Coming soon ..._
 
-=== "Bash"
+=== ":simple-curl: cURL"
 
     ```bash
     ```
 
-=== "Rust"
+=== ":simple-rust: Rust"
 
     ```rust
     ```
 
-=== "Python"
+=== ":simple-python: Python"
 
     ```python
     ```

--- a/docs/get_started/basic_usage/07_How-To-EventNotification.md
+++ b/docs/get_started/basic_usage/07_How-To-EventNotification.md
@@ -15,17 +15,17 @@ After subscription, you will receive mail notifications if something happens wit
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     ```
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     ```
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     ```
 
 
@@ -35,15 +35,15 @@ After subscription, you will receive mail notifications if something happens wit
 
 === ":simple-curl: cURL"
 
-    ```bash
+    ```bash linenums="1"
     ```
 
 === ":simple-rust: Rust"
 
-    ```rust
+    ```rust linenums="1"
     ```
 
 === ":simple-python: Python"
 
-    ```python
+    ```python linenums="1"
     ```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -45,7 +45,7 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.highlight:
-      anchor_linenums: true
+      anchor_linenums: false
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:


### PR DESCRIPTION
Small changes that affects the display of content tabs and code blocks.

## Changes:

* Replace content tab titles `Bash` with `cURL`
* Extend content tab titles with fitting icons
* Extension of code blocks with line numbering to improve clarity and simplify referencing