### PR TITLE
Update documentation to API 0.5.0-beta.8

### DIFF
--- a/docs/get_started/basic_usage/04_How-To-Collections.md
+++ b/docs/get_started/basic_usage/04_How-To-Collections.md
@@ -321,7 +321,6 @@ API example for updating a Collection.
       {
         "name": "UpdatedDummyCollection",
         "description": "Updated description of a dummy collection.",
-        "projectId": "<project-id>",
         "labels": [
           {
             "key": "LabelKey",
@@ -354,7 +353,6 @@ API example for updating a Collection.
         collection_id: "<collection-id>".to_string(),
         name: "Rust-API-Updated-Collection".to_string(),
         description: "This collection was updated through the Rust API.".to_string(),
-        project_id: "<project-id>".to_string(),
         labels: vec![KeyValue {
             key: "LabelKey".to_string(),
             value: "LabelValue".to_string(),
@@ -385,7 +383,6 @@ API example for updating a Collection.
     ```python linenums="1"
     # Create tonic/ArunaAPI request to update a collections name and description
     request = UpdateCollectionRequest(
-        project_id="<project-id>",
         collection_id="<collection-id>",
         name="Python-API-Updated-Collection",
         description="This collection was updated with the gRPC Python API client.",
@@ -501,7 +498,6 @@ API examples for deleting a Collection.
     # Native JSON request to delete a collection
     curl -d '
       {
-        "projectId": "<project-id>",
         "force": false
       }' \
          -H 'Authorization: Bearer <API_TOKEN>' \
@@ -513,7 +509,6 @@ API examples for deleting a Collection.
     # Native JSON request to force delete a collection with force
     curl -d '
       {
-        "projectId": "<project-id>",
         "force": true
       }' \
          -H 'Authorization: Bearer <API_TOKEN>' \
@@ -527,7 +522,6 @@ API examples for deleting a Collection.
     // Create tonic/ArunaAPI request to delete a collection
     let delete_request = DeleteCollectionRequest {
         collection_id: "<collection-id>".to_string(),
-        project_id: "<project-id>".to_string(),
         force: false
     };
     
@@ -545,7 +539,6 @@ API examples for deleting a Collection.
     // Create tonic/ArunaAPI request to delete a collection with force
     let delete_request = DeleteCollectionRequest {
         collection_id: "<collection-id>".to_string(),
-        project_id: "<project-id>".to_string(),
         force: true
     };
     
@@ -565,7 +558,6 @@ API examples for deleting a Collection.
     # Create tonic/ArunaAPI request to delete a collection
     request = DeleteCollectionRequest(
         collection_id="<collection-id>",
-        project_id="<project-id>",
         force=False
     )
 
@@ -580,7 +572,6 @@ API examples for deleting a Collection.
     # Create tonic/ArunaAPI request to delete a collection with force
     request = DeleteCollectionRequest(
         collection_id="<collection-id>",
-        project_id="<project-id>",
         force=True
     )
 

--- a/docs/get_started/basic_usage/05_How-To-Objects.md
+++ b/docs/get_started/basic_usage/05_How-To-Objects.md
@@ -1035,6 +1035,13 @@ This can be done with an individual request or directly while getting informatio
 
 Objects can still be updated after finishing.
 
+!!! Note
+
+    Concurrent updates from different collections are possible but discouraged.
+
+    If you want to explicitly update an object without paying attention to whether 
+    it is being updated by someone else at that moment, the `force` parameter can be used.
+
 !!! Info
 
     This request needs at least MODIFY permissions on the Object's Collection or the Project under which the Collection is registered.
@@ -1141,7 +1148,8 @@ Comparable to the Object initialization process, the updated Object must be fini
         "reupload": false,
         "preferredEndpointId": "",
         "multiPart": false,
-        "isSpecification": false
+        "isSpecification": false,
+        "force": false
       }' \
          -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -1189,7 +1197,8 @@ Comparable to the Object initialization process, the updated Object must be fini
         reupload: false,
         preferred_endpoint_id: "".to_string(),
         multi_part: false,
-        is_specification: false
+        is_specification: false,
+        force: false
     };
     
     // Send the request to the AOS instance gRPC gateway
@@ -1252,7 +1261,8 @@ Comparable to the Object initialization process, the updated Object must be fini
         reupload=False,
         preferred_endpoint_id="",  # Parameter can also be omitted if empty
         multi_part=False,  # Parameter can also be omitted if `reupload=False`
-        is_specification=False
+        is_specification=False,
+        force=False
     )
 
     # Send the request to the AOS instance gRPC gateway
@@ -1308,7 +1318,8 @@ Comparable to the Object initialization process, the updated Object must be fini
         "reupload": true,
         "preferredEndpointId": "",
         "multiPart": false,
-        "isSpecification": false
+        "isSpecification": false,
+        "force": false
       }' \
          -H 'Authorization: Bearer <API_TOKEN>' \
          -H 'Content-Type: application/json' \
@@ -1364,7 +1375,8 @@ Comparable to the Object initialization process, the updated Object must be fini
         reupload: true,
         preferred_endpoint_id: "".to_string(),
         multi_part: false,
-        is_specification: false
+        is_specification: false,
+        force: false
     };
     
     // Send the request to the AOS instance gRPC gateway
@@ -1468,7 +1480,8 @@ Comparable to the Object initialization process, the updated Object must be fini
         reupload=True,
         preferred_endpoint_id="",  # Parameter can also be omitted if empty
         multi_part=False,  # Parameter can also be omitted if `reupload=False`
-        is_specification=False
+        is_specification=False,
+        force=False
     )
 
     # Send the request to the AOS instance gRPC gateway

--- a/docs/get_started/basic_usage/05_How-To-Objects.md
+++ b/docs/get_started/basic_usage/05_How-To-Objects.md
@@ -1041,7 +1041,7 @@ Objects can still be updated after finishing.
 
 ### Update which does not create a new revision
 
-Just adding one or multiple labels to an Object does not create a new revision.
+Just adding one or multiple labels to an Object does not create a new revision with this specific request.
 
 === ":simple-curl: cURL"
 
@@ -1065,7 +1065,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
 
     ```rust linenums="1"
     // Create tonic/ArunaAPI request to add a label to an object
-    let add_request = AddLabelToObjectRequest {
+    let add_request = AddLabelsToObjectRequest {
         object_id: "<object-id>".to_string(),
         collection_id: "<collection-id>".to_string(),
         labels_to_add: vec![KeyValue {
@@ -1088,7 +1088,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
 
     ```python linenums="1"
     # Create tonic/ArunaAPI request to add a label to an object
-    request = AddLabelToObjectRequest(
+    request = AddLabelsToObjectRequest(
         object_id="<object-id>",
         collection_id="<collection-id>",
         labels_to_add=[KeyValue(
@@ -1098,7 +1098,7 @@ Just adding one or multiple labels to an Object does not create a new revision.
     )
 
     # Send the request to the AOS instance gRPC gateway
-    response = client.object_client.AddLabelToObject(request=request)
+    response = client.object_client.AddLabelsToObject(request=request)
 
     # Do something with the response
     print(f'{response}')

--- a/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
+++ b/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
@@ -588,15 +588,16 @@ There is also the possibility to only fetch the objects marked as metadata of th
 
 ## Update ObjectGroup
 
-ObjectGroups can also be updated after creation. 
+ObjectGroups can also be updated after creation.
 
-!!! Info
-
-    This request needs at least MODIFY permissions on the Object's Collection or the Project under which the Collection is registered.
 
 ### Update which does not create a new revision
 
 Just adding one or multiple labels to an Object does not create a new revision with this specific request.
+
+!!! Info
+
+    This request needs at least MODIFY permissions on the Object's Collection or the Project under which the Collection is registered.
 
 === ":simple-curl: cURL"
 

--- a/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
+++ b/docs/get_started/basic_usage/06_How-To-ObjectGroups.md
@@ -436,6 +436,7 @@ You can also fetch multiple ObjectGroups of a Collection at once.
     print(f'{response}')
     ```
 
+
 ## Get ObjectGroup Objects
 
 Information of the containing Objects have to be requested separately.
@@ -587,7 +588,80 @@ There is also the possibility to only fetch the objects marked as metadata of th
 
 ## Update ObjectGroup
 
-Updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
+ObjectGroups can also be updated after creation. 
+
+!!! Info
+
+    This request needs at least MODIFY permissions on the Object's Collection or the Project under which the Collection is registered.
+
+### Update which does not create a new revision
+
+Just adding one or multiple labels to an Object does not create a new revision with this specific request.
+
+=== ":simple-curl: cURL"
+
+    ```bash linenums="1"
+    # Native JSON request to add a label to an object 
+    curl -d '
+      {
+        "labelsToAdd": [
+          {
+            "key": "AnotherKey",
+            "value": "AnotherValue"
+         }
+       ]
+      }' \
+         -H 'Authorization: Bearer <API_TOKEN>' \
+         -H 'Content-Type: application/json' \
+         -X PATCH https://<URL-to-AOS-instance-API-gateway>/v1/collection/{collection_id}/group/{group_id}/add_labels
+    ```
+
+=== ":simple-rust: Rust"
+
+    ```rust linenums="1"
+    // Create tonic/ArunaAPI request to add a label to an object group
+    let add_request = AddLabelsToObjectGroupRequest {
+        collection_id: "<collection-id>".to_string(),
+        group_id: "<object-group-id>".to_string(),
+        labels_to_add: vec![KeyValue {
+            key: "AnotherKey".to_string(),
+            value: "AnotherValue".to_string(),
+        }],
+    };
+    
+    // Send the request to the AOS instance gRPC gateway
+    let response = object_group_client.add_labels_to_object_group(add_request)
+                                      .await
+                                      .unwrap()
+                                      .into_inner();
+    
+    // Do something with the response
+    println!("{:#?}", response);
+    ```
+
+=== ":simple-python: Python"
+
+    ```python linenums="1"
+    # Create tonic/ArunaAPI request to add a label to an object group
+    request = AddLabelsToObjectGroupRequest(
+        collection_id="<collection-id>",
+        group_id="<object-id>",
+        labels_to_add=[KeyValue(
+            key="AnotherKey",
+            value="AnotherValue"
+        )]
+    )
+
+    # Send the request to the AOS instance gRPC gateway
+    response = client.object_group_client.AddLabelsToObjectGroup(request=request)
+
+    # Do something with the response
+    print(f'{response}')
+    ```
+
+### Update which creates a new revision
+
+Otherwise, updating an ObjectGroup itself always creates a new revision of the ObjectGroup.
 
 !!! Note 
 


### PR DESCRIPTION
Adapt documentation to API version 0.5.0-beta.8.

## Version 0.5.0-beta.8

* Remove needless `project_id` parameter from specific collection requests 
* Added `force` flag to object update request
* Renamed `AddLabelToObject...` to `AddLabelsToObject...`
* Added `AddLabelsToObjectGroup` equivalent to the corresponding RPC in objects