### PR TITLE
Migrate to documentation versioning with mike

### DIFF
--- a/.github/workflows/mkdocs-build-deploy.yml
+++ b/.github/workflows/mkdocs-build-deploy.yml
@@ -2,7 +2,7 @@ name: Site build and deploy on push
 on:
   push:
     branches:
-      - 'v*.*' # Always build/deploy on version branch update
+      - 'v*.*' # Always deploy on version branch update
 
 jobs:
   deploy:
@@ -34,6 +34,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"

--- a/.github/workflows/mkdocs-build-deploy.yml
+++ b/.github/workflows/mkdocs-build-deploy.yml
@@ -2,35 +2,42 @@ name: Site build and deploy on push
 on:
   push:
     branches:
-      - master 
-      - main
+      - 'v*.*' # Always build/deploy on version branch update
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      
+        with:
+          fetch-depth: 0 # fetch all commits/branches
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
-          
+
       - name: Update pip
         run: pip install --upgrade pip
-        
+
       - name: Install mkdocs-material
-        run: pip install mkdocs-material 
-        
+        run: pip install mkdocs-material
+
       - name: Install mkdocs-glightbox
         run: pip install mkdocs-glightbox
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d %H:%M:%S')"
+      - name: Install mike
+        run: pip install mike
 
-      - name: Configuration before deploy
-        run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
-        
-      - name: Deploy mkdocs site to gh_pages 
-        run: mkdocs gh-deploy --verbose --force --clean -m "Automatic site deployment - ${{ steps.date.outputs.date }}"
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Deploy version site to gh_pages with mike
+        run: mike deploy -F mkdocs.yaml -p ${{ steps.extract_branch.outputs.branch }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the general documentation for the Aruna Object Storage 
 
 This includes a basic usage guide, the internal data structure, the entity-relationship model, some generic user story playbooks, theoretical concepts, and much more in the future.
 
-Deeper technical documentation can be found in the implementation repositories.
+Deeper technical documentation can be found in the implementation repositories which are briefly introduced below.
 Details on the individual structures can be found in the API documentation and/or the [Internal data structure](https://ArunaStorage.github.io/Documentation/internal_data_structure/internal_data_structure/) part of this repository.
 
 [🌐 **The complete AOS documentation is available via GitHub Pages** 🌐](https://ArunaStorage.github.io/Documentation)
@@ -26,7 +26,7 @@ A more detailed description of the individual resources can be found in the [com
 
 The API is designed generally with Google Protocol Buffers. With the release of a new API version, the client libraries are automatically compiled and updated to the latest version.
 The API is fundamentally backwards compatible, which means that users' applications will continue to work as usual before they also decide to move to the new version.
-The API currently contains part that are not fully implemented in the backend yet. For testing please use those components that are marked with "STABLE"
+The API currently contains part that are not fully implemented in the backend yet. For testing please use those components that are marked with "STABLE".
 
 - Rust API stubs: [GitHub](https://github.com/ArunaStorage/rust-api) or [crates.io](https://crates.io/crates/aruna-rust-api)
 - Go API stubs: [GitHub](https://github.com/ArunaStorage/go-api)
@@ -39,10 +39,10 @@ The API currently contains part that are not fully implemented in the backend ye
 
 The implementation of the API that handles the incoming requests.
 
-> Aruna Object Storage is data lake application with API that manages scientific data objects according to FAIR principles.
-> It interacts with multiple data storage backends (e.g. S3, File ...) via the DataProxy application and stores a rich and queryable set of metadata about stored objects in a
-> postgres compatible database (e.g. CockroachDB).
-> Aruna is conceptually geo-redundant with multiple dataset and database locations. Users can choose where and how to store their data.
+> Aruna Object Storage is a geo-redundant data lake storage system that manages scientific data 
+> and a rich set of associated metadata according to FAIR principles.
+
+> It supports multiple data storage backends (e.g. S3, File ...) via a DataProxy that exposes a S3-compatible interface.
 
 ### **AOS Data Proxy**
 
@@ -50,19 +50,20 @@ The implementation of the API that handles the incoming requests.
 
 This is the internal server implementation handling the communication between the data storage backend which is used and the specific AOS instance.
 
-> The DataProxy service is designed to handle data transfers AOS. It starts two server: One server implements the internal proxy api from the official AOS gRPC API.
+> The DataProxy service is designed to handle data transfers AOS. It starts two server: 
+> One server implements the internal proxy api from the official AOS gRPC API.
 > The other server handles the transfer of the actual data. All data access is handled through presigned URLs.
 
 ### **AOS CLI**
 
 [**Main Aruna CLI repository**](https://github.com/ArunaStorage/ArunaCLI)
 
-> This is a simple CLI application for the ScienceObjectsDB API.
-> Its currently work in progress and will be developed along with the API. Neither concept nor implementation are final.
+>This is a simple CLI application for the Aruna API. 
+> It is currently work in progress and will be developed along with the API. Neither concept nor implementation are final.
 
-- **Notification system**
+### **Notification system**
 
-The storage system has a notification system that can be used to receive change notification on specific resources.
+The AOS includes a notification system that can be used to receive change notifications on specific resources.
 
 The notification system is currently still in the implementation phase but will be available soon.
 
@@ -70,10 +71,10 @@ The notification system is currently still in the implementation phase but will 
 
 ## Implementation design trivia
 
-- An RDBMS will be used as database backend for the AOS Server
-- The AOS Server, Data Proxy nd CLI will be implemented in [Rust](https://www.rust-lang.org/)
-- The base API interface will be defined using [Protocol Buffers](https://developers.google.com/protocol-buffers)
+- A RDBMS will be used as database backend for the AOS Server
+- The AOS Server, Data Proxy and CLI are implemented in [Rust](https://www.rust-lang.org/)
+- The base API interface is defined using [Protocol Buffers](https://developers.google.com/protocol-buffers)
 - All endpoints work with JSON over HTTP just as they do with requests made via gRPC from individual clients
-- [Client stubs](#aos-api) will be generated for major programming languages on every API release
+- [Client stubs](#aos-api) will be generated for major programming languages on every API release ([listed here](#aos-api))
 - A [basic CLI client](https://github.com/ArunaStorage/ArunaCLI) will be offered to simplify the usage entry barrier
 - A [web UI](https://web.aruna.nfdi-dev.gi.denbi.de/ui/) is available for demonstration purposes

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -26,6 +26,7 @@ theme:
   name: material
   logo: assets/logo-claim.png
   favicon: assets/logo-icon.png
+  custom_dir: overrides
   features:
     - content.code.annotate
     - navigation.tabs

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -55,3 +55,10 @@ markdown_extensions:
 plugins:
   - glightbox
   - search
+  - mike:
+      version_selector: true
+      css_dir: stylesheets
+
+extra:
+  version:
+    provider: mike

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,8 +1,8 @@
 site_name: Aruna Object Storage Documentation
 site_url: https://ArunaStorage.github.io/Documentation
 
-repo_name: 'ArunaStorage/Documentation'
-repo_url: 'https://github.com/ArunaStorage/Documentation'
+repo_name: 'ArunaStorage/ArunaAPI'
+repo_url: 'https://github.com/ArunaStorage/ArunaPI'
 
 docs_dir: docs/
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -26,7 +26,7 @@ theme:
   name: material
   logo: assets/logo-claim.png
   favicon: assets/logo-icon.png
-  custom_dir: overrides
+  #custom_dir: overrides
   features:
     - content.code.annotate
     - navigation.tabs

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+You're not viewing the latest version.
+<a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+</a>
+{% endblock %}


### PR DESCRIPTION
This refactors all necessary parts to introduce versioning to the documentation. 
This is useful as users could have missed the opportunity to migrate their instance to the latest version and still need the dpocumentation for the version they're running on.

## Changes

* Adjust build/deploy GitHub Actions workflow file
    * Runs on push to version branches to update version specific documentation
    * Uses [mike](https://github.com/jimporter/mike) for build and deployment
* Add not-latest-version warning which can be displayed on outdated versions (disabled by default)
* Documentation links to the [ArunaAPI](https://github.com/ArunaStorage/ArunaAPI) repository instead of itself